### PR TITLE
Summary statistics

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -42,3 +42,10 @@ v1.0.0 6/26/2014 -- Significant changes have been made, which make some function
 (7) MultivariateDistribution is a new distribution type which allows you to specify distributions over an arbitrary number of independent distributions of any type. You specify it by passing in a list of distributions like the following: MultivariateDistribution( [ NormalDistribution( 5, 2 ), ExponentialDistribution( 10 ) ] ). All current methods work with it, but now all sequence items must be tuples of length equal to the number of distributions.
 
 (8) Previously, rows were normalized during the forward and backward algorithm. This caused huge slow downs for no gain, as the logsumexp function handled underflow. These have been removed. 
+
+v1.0.1a, 8/26/2014 --
+(1) Distribution inertia added for all distributions. This means that parameters for the distributions are updated to be inertia*prior_parameters + (1-inertia)*new_parameters. This can be triggered using `distribution_inertia` in the `Model.train` method.
+
+(2) Summary statistics implemented for Baum-Welch training. This involves summarizing one sequence at a time and storing the appropriate summary statistics to the distribution object using `Distribution.summarize( items, weights )`, and then updating the parameters using these summary statistics and an appropriate inertia with `Distribution.from_summarize( inertia=0.0 )`. This makes training on large numbers of sequences always faster, but training on small numbers of long sequences take slightly longer. 
+
+(3) Nosetests significantly expanded to include more tests. This includes a new file `test_training.py`, which has a large number of tests on the Viterbi and Baum-Welch training algorithms, with different parameters. This also includes expanded testing of each distribution, and each of the training functions for that sample.

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,399 @@
+from __future__ import  (division, print_function)
+
+from yahmm.yahmm import *
+from nose.tools import with_setup
+import random
+import numpy as np
+import time
+
+def setup():
+	'''
+	Build a model that we want to use to test sequences. This model will
+	be somewhat complicated, in order to extensively test YAHMM. This will be
+	a three state global sequence alignment HMM. The HMM models a reference of
+	'ACT', with pseudocounts to allow for slight deviations from this
+	reference.
+	'''
+
+	random.seed(0)
+
+	global model
+	global m1, m2, m3
+	model = Model( "Global Alignment")
+
+	# Define the distribution for insertions
+	i_d = DiscreteDistribution( { 'A': 0.25, 'C': 0.25, 'G': 0.25, 'T': 0.25 } )
+
+	# Create the insert states
+	i0 = State( i_d, name="I0" )
+	i1 = State( i_d, name="I1" )
+	i2 = State( i_d, name="I2" )
+	i3 = State( i_d, name="I3" )
+
+	# Create the match states
+	m1 = State( DiscreteDistribution({ "A": 0.95, 'C': 0.01, 'G': 0.01, 'T': 0.02 }) , name="M1" )
+	m2 = State( DiscreteDistribution({ "A": 0.003, 'C': 0.99, 'G': 0.003, 'T': 0.004 }) , name="M2" )
+	m3 = State( DiscreteDistribution({ "A": 0.01, 'C': 0.01, 'G': 0.01, 'T': 0.97 }) , name="M3" )
+
+	# Create the delete states
+	d1 = State( None, name="D1" )
+	d2 = State( None, name="D2" )
+	d3 = State( None, name="D3" )
+
+	# Add all the states to the model
+	model.add_states( [i0, i1, i2, i3, m1, m2, m3, d1, d2, d3 ] )
+
+	# Create transitions from match states
+	model.add_transition( model.start, m1, 0.9 )
+	model.add_transition( model.start, i0, 0.1 )
+	model.add_transition( m1, m2, 0.9 )
+	model.add_transition( m1, i1, 0.05 )
+	model.add_transition( m1, d2, 0.05 )
+	model.add_transition( m2, m3, 0.9 )
+	model.add_transition( m2, i2, 0.05 )
+	model.add_transition( m2, d3, 0.05 )
+	model.add_transition( m3, model.end, 0.9 )
+	model.add_transition( m3, i3, 0.1 )
+
+	# Create transitions from insert states
+	model.add_transition( i0, i0, 0.70 )
+	model.add_transition( i0, d1, 0.15 )
+	model.add_transition( i0, m1, 0.15 )
+
+	model.add_transition( i1, i1, 0.70 )
+	model.add_transition( i1, d2, 0.15 )
+	model.add_transition( i1, m2, 0.15 )
+
+	model.add_transition( i2, i2, 0.70 )
+	model.add_transition( i2, d3, 0.15 )
+	model.add_transition( i2, m3, 0.15 )
+
+	model.add_transition( i3, i3, 0.85 )
+	model.add_transition( i3, model.end, 0.15 )
+
+	# Create transitions from delete states
+	model.add_transition( d1, d2, 0.15 )
+	model.add_transition( d1, i1, 0.15 )
+	model.add_transition( d1, m2, 0.70 ) 
+
+	model.add_transition( d2, d3, 0.15 )
+	model.add_transition( d2, i2, 0.15 )
+	model.add_transition( d2, m3, 0.70 )
+
+	model.add_transition( d3, i3, 0.30 )
+	model.add_transition( d3, model.end, 0.70 )
+
+	# Call bake to finalize the structure of the model.
+	model.bake()
+
+def teardown():
+	'''
+	Remove the model at the end of the unit testing. Since it is stored in a
+	global variance, simply delete it.
+	'''
+
+	pass
+
+@with_setup( setup, teardown )
+def test_viterbi_train():
+	'''
+	Test the model using various parameter settings for Viterbi training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='viterbi', 
+									 verbose=False, 
+									 use_pseudocount=True )
+
+	assert round( total_improvement, 4 ) == 0.4654
+
+@with_setup( setup, teardown )
+def test_viterbi_train_no_pseudocount():
+	'''
+	Test the model using various parameter settings for Viterbi training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='viterbi', 
+									 verbose=False, 
+									 use_pseudocount=False )
+
+	assert round( total_improvement, 4 ) == 0.577
+
+@with_setup( setup, teardown )
+def test_viterbi_train_w_pseudocount():
+	'''
+	Test the model using various parameter settings for Viterbi training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='viterbi', 
+									 verbose=False, 
+									 transition_pseudocount=1. )
+
+	assert round( total_improvement, 4 ) == 0.2124
+
+@with_setup( setup, teardown )
+def test_viterbi_train_w_pseudocount_priors():
+	'''
+	Test the model using various parameter settings for Viterbi training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='viterbi', 
+									 verbose=False, 
+									 transition_pseudocount=0.278,
+									 use_pseudocount=True )
+
+	assert round( total_improvement, 4 ) == 0.3635
+
+@with_setup( setup, teardown )
+def test_viterbi_train_w_inertia():
+	'''
+	Test the model using various parameter settings for Viterbi training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='viterbi', 
+									 verbose=False, 
+									 edge_inertia=0.193 )
+
+	assert round( total_improvement, 4 ) == 0.2808
+
+@with_setup( setup, teardown )
+def test_viterbi_train_w_inertia2():
+	'''
+	Test the model using various parameter settings for Viterbi training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='viterbi', 
+									 verbose=False, 
+									 edge_inertia=0.82 )
+
+	assert round( total_improvement, 4 ) == -0.1789
+
+@with_setup( setup, teardown )
+def test_viterbi_train_w_pseudocount_inertia():
+	'''
+	Test the model using various parameter settings for Viterbi training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='viterbi', 
+									 verbose=False, 
+									 edge_inertia=0.23,
+									 use_pseudocount=True )
+	print( round( total_improvement, 4 ) )
+	assert round( total_improvement, 4 ) == 0.1573
+
+@with_setup( setup, teardown )
+def test_bw_train():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 use_pseudocount=True,
+									 max_iterations=5 )
+	
+	assert round( total_improvement, 4 ) == 0.4398
+
+@with_setup( setup, teardown )
+def test_bw_train_no_pseudocount():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 use_pseudocount=False,
+									 max_iterations=5 )
+	
+	assert round( total_improvement, 4 ) == 0.5718
+
+@with_setup( setup, teardown )
+def test_bw_train_w_pseudocount():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 transition_pseudocount=0.123,
+									 max_iterations=5 )
+	
+	assert round( total_improvement, 4 ) == 0.521
+
+@with_setup( setup, teardown )
+def test_bw_train_w_pseudocount_priors():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 transition_pseudocount=0.278,
+									 use_pseudocount=True,
+									 max_iterations=5 )
+	
+	assert round( total_improvement, 4 ) == 0.3277
+
+@with_setup( setup, teardown )
+def test_bw_train_w_inertia():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 edge_inertia=0.193,
+									 max_iterations=5 )
+	
+	assert round( total_improvement, 4 ) == 0.5398
+
+@with_setup( setup, teardown )
+def test_bw_train_w_inertia2():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 edge_inertia=0.82,
+									 max_iterations=5 )
+	
+	assert round( total_improvement, 4 ) == -0.3285
+
+@with_setup( setup, teardown )
+def test_bw_train_w_pseudocount_inertia():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 edge_inertia=0.02,
+									 use_pseudocount=True,
+									 max_iterations=5 )
+	
+	assert round( total_improvement, 4 ) == 0.4363
+
+@with_setup( setup, teardown )
+def test_bw_train_w_frozen_distributions():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 distribution_inertia=1.00,
+									 max_iterations=5 )
+
+	assert round( total_improvement, 4 ) == -0.1698
+
+@with_setup( setup, teardown )
+def test_bw_train_w_frozen_edges():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 edge_inertia=1.00,
+									 max_iterations=5 )
+
+	assert round( total_improvement, 4 ) == -0.3488
+
+@with_setup( setup, teardown )
+def test_bw_train_w_edge_a_distribution_inertia():
+	'''
+	Test the model using various parameter settings for Baum-Welch training.
+	'''
+
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
+
+	total_improvement = model.train( seqs, 
+									 algorithm='baum-welch', 
+									 verbose=False, 
+									 edge_inertia=0.5,
+									 distribution_inertia=0.5,
+									 max_iterations=5 )
+
+	assert round( total_improvement, 4 ) == -0.1702

--- a/yahmm/yahmm.pyx
+++ b/yahmm/yahmm.pyx
@@ -103,8 +103,6 @@ cdef class Distribution(object):
 
 	cdef public str name
 	cdef public list parameters, summaries
-	cdef public numpy.ndarray points
-	cdef public numpy.ndarray weights
 
 	def __init__(self):
 		"""
@@ -119,6 +117,7 @@ cdef class Distribution(object):
 
 		self.name = "Distribution"
 		self.parameters = []
+		self.summaries = []
 
 	def __str__( self ):
 		"""
@@ -184,10 +183,10 @@ cdef class Distribution(object):
 
 			# If even one summary lacks weights, then weights can't be assigned
 			# to any of the points.
-			if weights is None:
+			if weights is not None:
 				weights = numpy.concatenate( [prior_weights, weights] )
 
-			self.summaries = [ prior_items, weights ]
+			self.summaries = [ items, weights ]
 
 	def from_summaries( self ):
 		"""
@@ -235,7 +234,7 @@ cdef class UniformDistribution( Distribution ):
 		
 		return random.uniform(self.parameters[0], self.parameters[1])
 		
-	def from_sample(self, items, weights=None):
+	def from_sample (self, items, weights=None, inertia=0.0 ):
 		"""
 		Set the parameters of this Distribution to maximize the likelihood of 
 		the given sample. Items holds some sort of sequence. If weights is 
@@ -251,10 +250,14 @@ cdef class UniformDistribution( Distribution ):
 			# No sample, so just ignore it and keep our old parameters.
 			return
 		
-		# The ML uniform distribution is just min to max.
-		# Weights don't matter for this
-		self.parameters[0] = numpy.min(items)
-		self.parameters[1] = numpy.max(items)
+		# The ML uniform distribution is just min to max. Weights don't matter
+		# for this.
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		prior_min, prior_max = self.parameters
+		self.parameters[0] = prior_min*inertia + numpy.min(items)*(1-inertia)
+		self.parameters[1] = prior_max*inertia + numpy.max(items)*(1-inertia)
 
 	def summarize( self, items, weights=None ):
 		'''
@@ -272,18 +275,27 @@ cdef class UniformDistribution( Distribution ):
 			return
 
 		items = numpy.asarray( items )
+
+		# Record the min and max, which are the summary statistics for a
+		# uniform distribution.
 		self.summaries.append([ items.min(), items.max() ])
 		
-	def from_summaries( self ):
+	def from_summaries( self, inertia=0.0 ):
 		'''
-		Takes in a series of summaries, represented as a mean, a variance, and
-		a weight, and updates the underlying distribution. Notes on how to do
-		this for a Gaussian distribution were taken from here:
-		http://math.stackexchange.com/questions/453113/how-to-merge-two-gaussians
+		Takes in a series of summaries, consisting of the minimum and maximum
+		of a sample, and determine the global minimum and maximum.
 		'''
 
 		summaries = numpy.asarray( self.summaries )
-		self.parameters = [ summaries[:,0].min(), summaries[:,1].max() ]
+
+		# Load the prior parameters
+		prior_min, prior_max = self.parameters
+
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		self.parameters = [ prior_min*inertia + summaries[:,0].min()*(1-inertia), 
+							prior_max*inertia + summaries[:,1].max()*(1-inertia) ]
 		self.summaries = []
 
 cdef class NormalDistribution( Distribution ):
@@ -335,7 +347,7 @@ cdef class NormalDistribution( Distribution ):
 		# This uses the same parameterization
 		return random.normalvariate(*self.parameters)
 		
-	def from_sample( self, items, weights=None, min_std=0.01 ):
+	def from_sample( self, items, weights=None, inertia=0.0, min_std=0.01 ):
 		"""
 		Set the parameters of this Distribution to maximize the likelihood of 
 		the given sample. Items holds some sort of sequence. If weights is 
@@ -388,8 +400,13 @@ cdef class NormalDistribution( Distribution ):
 		
 		# Enforce min std
 		std = max( numpy.array([std, min_std]) )
-		# Set the parameters
-		self.parameters = [mean, std]
+		
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		prior_mean, prior_std = self.parameters
+		self.parameters = [ prior_mean*inertia + mean*(1-inertia), 
+							prior_std*inertia + std*(1-inertia) ]
 
 	def summarize( self, items, weights=None ):
 		'''
@@ -398,17 +415,24 @@ cdef class NormalDistribution( Distribution ):
 		'''
 
 		items = numpy.asarray( items )
+
+		# Calculate weights. If none are provided, give uniform weights
 		if weights is None:
 			weights = numpy.ones_like( items )
 		else:
 			weights = numpy.asarray( weights )
 
+		# Save the mean and variance, the summary statistics for a normal
+		# distribution.
 		mean = numpy.average( items, weights=weights )
 		variance = numpy.dot( items**2 - mean**2, weights ) / weights.sum()
+
+		# Append the mean, variance, and sum of the weights to give the weights
+		# of these statistics.
 		self.summaries.append( [ mean, variance, weights.sum() ] )
 		
 
-	def from_summaries( self ):
+	def from_summaries( self, inertia=0.0 ):
 		'''
 		Takes in a series of summaries, represented as a mean, a variance, and
 		a weight, and updates the underlying distribution. Notes on how to do
@@ -416,10 +440,13 @@ cdef class NormalDistribution( Distribution ):
 		http://math.stackexchange.com/questions/453113/how-to-merge-two-gaussians
 		'''
 
+		# If no summaries stored, don't do anything.
 		if len( self.summaries ) == 0:
 			return
 
 		summaries = numpy.asarray( self.summaries )
+
+		# Calculate the new mean and variance. 
 		mean = numpy.average( summaries[:,0], weights=summaries[:,2] )
 		variance = numpy.sum( [(v+m**2)*w for m, v, w in summaries] ) \
 			/ summaries[:,2].sum() - mean**2
@@ -429,7 +456,14 @@ cdef class NormalDistribution( Distribution ):
 		else:
 			std = 0
 
-		self.parameters = [ mean, std ]
+		# Get the previous parameters.
+		prior_mean, prior_std = self.parameters
+
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		self.parameters = [ prior_mean*inertia + mean*(1-inertia),
+							prior_std*inertia + std*(1-inertia) ]
 		self.summaries = []
 
 cdef class LogNormalDistribution( Distribution ):
@@ -471,7 +505,7 @@ cdef class LogNormalDistribution( Distribution ):
 
 		return numpy.random.lognormal( *self.parameters )
 
-	def from_sample( self, items, weights=None, min_std=0.01 ):
+	def from_sample( self, items, weights=None, inertia=0.0, min_std=0.01 ):
 		"""
 		Set the parameters of this distribution to maximize the likelihood of
 		the given samples. Items hold some sort of sequence over floats. If
@@ -524,8 +558,13 @@ cdef class LogNormalDistribution( Distribution ):
 		
 		# Enforce min std
 		std = max( numpy.array([std, min_std]) )
-		# Set the parameters
-		self.parameters = [mean, std]
+		
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		prior_mean, prior_std = self.parameters
+		self.parameters = [ prior_mean*inertia + mean*(1-inertia), 
+						    prior_std*inertia + std*(1-inertia) ]
 
 	def summarize( self, items, weights=None ):
 		'''
@@ -534,17 +573,23 @@ cdef class LogNormalDistribution( Distribution ):
 		'''
 
 		items = numpy.asarray( items )
+
+		# If no weights are specified, use uniform weights.
 		if weights is None:
 			weights = numpy.ones_like( items )
 		else:
 			weights = numpy.asarray( weights )
 
+		# Calculate the mean and variance, which are the summary statistics
+		# for a log-normal distribution.
 		mean = numpy.average( numpy.log(items), weights=weights )
 		variance = numpy.dot( numpy.log(items)**2 - mean**2, weights ) / weights.sum()
+		
+		# Save the summary statistics and the weights.
 		self.summaries.append( [ mean, variance, weights.sum() ] )
 		
 
-	def from_summaries( self ):
+	def from_summaries( self, inertia=0.0 ):
 		'''
 		Takes in a series of summaries, represented as a mean, a variance, and
 		a weight, and updates the underlying distribution. Notes on how to do
@@ -552,10 +597,13 @@ cdef class LogNormalDistribution( Distribution ):
 		http://math.stackexchange.com/questions/453113/how-to-merge-two-gaussians
 		'''
 
+		# If no summaries are provided, don't do anything.
 		if len( self.summaries ) == 0:
 			return
 
 		summaries = numpy.asarray( self.summaries )
+
+		# Calculate the mean and variance from the summary statistics.
 		mean = numpy.average( summaries[:,0], weights=summaries[:,2] )
 		variance = numpy.sum( [(v+m**2)*w for m, v, w in summaries] ) \
 			/ summaries[:,2].sum() - mean**2
@@ -565,7 +613,14 @@ cdef class LogNormalDistribution( Distribution ):
 		else:
 			std = 0
 
-		self.parameters = [ mean, std ]
+		# Load the previous parameters
+		prior_mean, prior_std = self.parameters
+
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		self.parameters = [ prior_mean*inertia + mean*(1-inertia), 
+						    prior_std*inertia + std*(1-inertia) ]
 		self.summaries = []
 
 cdef class ExtremeValueDistribution( Distribution ):
@@ -633,7 +688,7 @@ cdef class ExponentialDistribution( Distribution ):
 		
 		return random.expovariate(*self.parameters)
 		
-	def from_sample( self, items, weights=None ):
+	def from_sample( self, items, weights=None, inertia=0.0 ):
 		"""
 		Set the parameters of this Distribution to maximize the likelihood of 
 		the given sample. Items holds some sort of sequence. If weights is 
@@ -663,8 +718,13 @@ cdef class ExponentialDistribution( Distribution ):
 		# Compute the weighted mean
 		weighted_mean = numpy.average(items, weights=weights)
 		
-		# Update parameters
-		self.parameters[0] = 1.0 / weighted_mean
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		prior_rate = self.parameters[0]
+		rate = 1.0 / weighted_mean
+
+		self.parameters[0] = prior_rate*inertia + rate*(1-inertia)
 
 	def summarize( self, items, weights=None ):
 		'''
@@ -673,15 +733,18 @@ cdef class ExponentialDistribution( Distribution ):
 		'''
 
 		items = numpy.asarray( items )
+
+		# Either store the weights, or assign uniform weights to each item
 		if weights is None:
 			weights = numpy.ones_like( items )
 		else:
 			weights = numpy.asarray( weights )
 
+		# Calculate the summary statistic, which in this case is the mean.
 		mean = numpy.average( items, weights=weights )
 		self.summaries.append( [ mean, weights.sum() ] )
 
-	def from_summaries( self ):
+	def from_summaries( self, inertia=0.0 ):
 		'''
 		Takes in a series of summaries, represented as a mean, a variance, and
 		a weight, and updates the underlying distribution. Notes on how to do
@@ -689,12 +752,23 @@ cdef class ExponentialDistribution( Distribution ):
 		http://math.stackexchange.com/questions/453113/how-to-merge-two-gaussians
 		'''
 
+		# If no summaries, do nothing.
 		if len( self.summaries ) == 0:
 			return
 
 		summaries = numpy.asarray( self.summaries )
+
+		# Calculate the new parameter from the summary statistics.
 		mean = numpy.average( summaries[:,0], weights=summaries[:,1] )
-		self.parameters = [ 1.0 / mean ]
+
+		# Get the parameters
+		prior_rate = self.parameters[0]
+		rate = 1.0 / mean
+
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		self.parameters[0] = prior_rate*inertia + rate*(1-inertia)
 		self.summaries = []
 
 cdef class GammaDistribution( Distribution ):
@@ -738,7 +812,7 @@ cdef class GammaDistribution( Distribution ):
 		# alpha/beta are shape/scale. So we have to mess with the parameters.
 		return random.gammavariate(self.parameters[0], 1.0 / self.parameters[1])
 		
-	def from_sample( self, items, weights=None, epsilon=1E-9, 
+	def from_sample( self, items, weights=None, inertia=0.0, epsilon=1E-9, 
 		iteration_limit = 1000 ):
 		"""
 		Set the parameters of this Distribution to maximize the likelihood of 
@@ -835,8 +909,14 @@ cdef class GammaDistribution( Distribution ):
 		# Calculate the rate parameter
 		rate = 1.0 / (1.0 / (shape * weights.sum()) * items.dot(weights) )
 
-		# Set the estimated parameters
-		self.parameters = [shape, rate]    
+		# Get the previous parameters
+		prior_shape, prior_rate = self.parameters
+
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		self.parameters = [ prior_shape*inertia + shape*(1-inertia), 
+							prior_rate*inertia + rate*(1-inertia) ]    
 
 	def summarize( self, items, weights=None ):
 		"""
@@ -870,7 +950,8 @@ cdef class GammaDistribution( Distribution ):
 								 items.dot( weights ),
 								 weights.sum() ] )
 
-	def from_summaries( self, epsilon=1E-9, iteration_limit=1000 ):
+	def from_summaries( self, inertia=0.0, epsilon=1E-9, 
+		iteration_limit=1000 ):
 		'''
 		Set the parameters of this Distribution to maximize the likelihood of 
 		the given sample given the summaries which have been stored.
@@ -951,8 +1032,14 @@ cdef class GammaDistribution( Distribution ):
 		rate = 1.0 / (1.0 / (shape * summaries[:,3].sum()) * \
 			numpy.sum( summaries[:,2] ) )
 
-		# Set the estimated parameters
-		self.parameters = [shape, rate]
+		# Get the previous parameters
+		prior_shape, prior_rate = self.parameters
+
+		# Calculate the new parameters, respecting inertia, with an inertia
+		# of 0 being completely replacing the parameters, and an inertia of
+		# 1 being to ignore new training data.
+		self.parameters = [ prior_shape*inertia + shape*(1-inertia), 
+							prior_rate*inertia + rate*(1-inertia) ]
 		self.summaries = []  		
 
 cdef class InverseGammaDistribution( GammaDistribution ):
@@ -991,7 +1078,7 @@ cdef class InverseGammaDistribution( GammaDistribution ):
 		# Invert the sample from the gamma distribution.
 		return 1.0 / super( InverseGammaDistribution, self ).sample()
 		
-	def from_sample( self, items, weights=None ):
+	def from_sample( self, items, weights=None, inertia=0.0 ):
 		"""
 		Set the parameters of this Distribution to maximize the likelihood of 
 		the given sample. Items holds some sort of sequence. If weights is 
@@ -1000,7 +1087,7 @@ cdef class InverseGammaDistribution( GammaDistribution ):
 		
 		# Fit the gamma distribution on the inverted items.
 		super( InverseGammaDistribution, self ).from_sample( 1.0 / 
-			numpy.asarray( items ), weights=weights)
+			numpy.asarray( items ), weights=weights, inertia=inertia )
 
 	def summarize( self, items, weights=None ):
 		"""
@@ -1011,13 +1098,13 @@ cdef class InverseGammaDistribution( GammaDistribution ):
 		super( InverseGammaDistribution, self ).summarize( 
 			1.0 / numpy.asarray( items ),  weights=weights )
 
-	def from_summaries( self, epsilon=1E-9, iteration_limit=1000 ):
+	def from_summaries( self, inertia=0.0, epsilon=1E-9, iteration_limit=1000 ):
 		'''
 		Update the parameters based on the summaries stored.
 		'''
 
 		super( InverseGammaDistribution, self ).from_summaries(
-			epsilon=epsilon, iteration_limit=iteration_limit )
+			epsilon=epsilon, iteration_limit=iteration_limit, inertia=inertia )
 
 cdef class DiscreteDistribution(Distribution):
 	"""
@@ -1061,7 +1148,7 @@ cdef class DiscreteDistribution(Distribution):
 				return key
 			rand -= value
 	
-	def from_sample( self, items, weights=None ):
+	def from_sample( self, items, weights=None, inertia=0.0 ):
 		"""
 		Takes in an iterable representing samples from a distribution and
 		turn it into a discrete distribution. If no weights are provided,
@@ -1070,17 +1157,32 @@ cdef class DiscreteDistribution(Distribution):
 		"""
 
 		n = len( items )
+
+		# Normalize weights, or assign uniform probabilities
 		if weights is None:
 			weights = numpy.ones( n ) / n
 		else:
 			weights = numpy.array(weights) / numpy.sum(weights)
 
+		# Sum the weights seen for each character
 		characters = {}
 		for character, weight in it.izip( items, weights ):
 			try:
 				characters[character] += weight
 			except KeyError:
 				characters[character] = weight
+
+		# Adjust the new weights by the inertia
+		for character, weight in characters.items():
+			characters[character] = weight * (1-inertia)
+
+		# Adjust the old weights by the inertia
+		prior_characters = self.parameters[0]
+		for character, weight in prior_characters.items():
+			try:
+				characters[character] += weight * inertia
+			except KeyError:
+				characters[character] = weight * inertia
 
 		self.parameters = [ characters ]
 
@@ -1092,9 +1194,9 @@ cdef class DiscreteDistribution(Distribution):
 
 		n = len( items )
 		if weights is None:
-			weights = numpy.ones( n ) / len( n )
+			weights = numpy.ones( n )
 		else:
-			weights = numpy.asarray( weights ) / numpy.sum( weights )
+			weights = numpy.asarray( weights )
 
 		characters = self.summaries[0]
 		for character, weight in it.izip( items, weights ):
@@ -1104,9 +1206,9 @@ cdef class DiscreteDistribution(Distribution):
 				characters[character] = weight
 
 		self.summaries[0] = characters
-		self.summaries[1] += 1
+		self.summaries[1] += weights.sum()
 
-	def from_summaries( self ):
+	def from_summaries( self, inertia=0.0 ):
 		'''
 		Takes in a series of summaries and merge them.
 		'''
@@ -1114,10 +1216,22 @@ cdef class DiscreteDistribution(Distribution):
 		if len( self.summaries ) == 0:
 			return
 
-		characters, n = self.summaries 
+		# Unpack the variables
+		prior_characters = self.parameters[0]
+		characters, total_weight = self.summaries 
 
+		# Scale the characters by both the total number of weights and by
+		# the inertia.
 		for character, prob in characters.items():
-			characters[character] = prob / n 
+			characters[character] = ( prob / total_weight ) * (1-inertia)
+
+		# Adjust the old weights by the inertia
+		if inertia > 0.0:
+			for character, weight in prior_characters.items():
+				try:
+					characters[character] += weight * inertia
+				except KeyError:
+					characters[character] = weight * inertia
 
 		self.parameters = [ characters ]
 		self.summaries = [ {}, 0 ]
@@ -1168,14 +1282,16 @@ cdef class GaussianKernelDensity( Distribution ):
 		Weights are scaled so that they sum to 1. 
 		"""
 
+		points = numpy.asarray( points )
 		n = len(points)
+		
 		if weights:
-			self.weights = numpy.array(weights) / numpy.sum(weights)
+			weights = numpy.array(weights) / numpy.sum(weights)
 		else:
-			self.weights = numpy.ones( n ) / n 
+			weights = numpy.ones( n ) / n 
 
-		self.points = numpy.array( points )
-		self.parameters = [ self.points, bandwidth, self.weights ]
+		self.parameters = [ points, bandwidth, weights ]
+		self.summaries = []
 		self.name = "GaussianKernelDensity"
 
 	def log_probability( self, symbol ):
@@ -1221,20 +1337,31 @@ cdef class GaussianKernelDensity( Distribution ):
 		mu = numpy.random.choice( self.parameters[0], p=self.parameters[2] )
 		return random.gauss( mu, self.parameters[1] )
 
-	def from_sample( self, points, weights=None ):
+	def from_sample( self, points, weights=None, inertia=0.0 ):
 		"""
-		Replace the points, training without inertia.
+		Replace the points, allowing for inertia if specified.
 		"""
 
-		self.points = numpy.array( points )
-
+		points = numpy.asarray( points )
 		n = len(points)
-		if weights:
-			self.weights = numpy.array(weights) / numpy.sum(weights)
-		else:
-			self.weights = numpy.ones( n ) / n 
 
-		self.parameters = [ self.points, self.parameters[1], self.weights ]
+		# Get the weights, or assign uniform weights
+		if weights:
+			weights = numpy.array(weights) / numpy.sum(weights)
+		else:
+			weights = numpy.ones( n ) / n 
+
+		# If no inertia, get rid of the previous points
+		if inertia == 0.0:
+			self.parameters[0] = points
+			self.parameters[2] = weights
+
+		# Otherwise adjust weights appropriately
+		else: 
+			self.parameters[0] = numpy.concatenate( ( self.parameters[0],
+													  points ) )
+			self.parameters[2] = numpy.concatenate( ( self.parameters[2]*inertia,
+													  weights*(1-inertia) ) )
 
 cdef class UniformKernelDensity( Distribution ):
 	"""
@@ -1250,14 +1377,15 @@ cdef class UniformKernelDensity( Distribution ):
 		Weights are scaled so that they sum to 1. 
 		"""
 
+		points = numpy.asarray( points )
 		n = len(points)
 		if weights:
-			self.weights = numpy.array(weights) / numpy.sum(weights)
+			weights = numpy.array(weights) / numpy.sum(weights)
 		else:
-			self.weights = numpy.ones( n ) / n 
+			weights = numpy.ones( n ) / n 
 
-		self.points = numpy.array( points )
-		self.parameters = [ self.points, bandwidth, self.weights ]
+		self.parameters = [ points, bandwidth, weights ]
+		self.summaries = []
 		self.name = "UniformKernelDensity"
 
 	def log_probability( self, symbol ):
@@ -1303,24 +1431,35 @@ cdef class UniformKernelDensity( Distribution ):
 		or uniformly if not, and then randomly sampling from that point's PDF.
 		"""
 
-		mu = numpy.random.choice( self.points, p=self.weights )
+		mu = numpy.random.choice( self.parameters[0], p=self.parameters[2] )
 		bandwidth = self.parameters[1]
 		return random.uniform( mu-bandwidth, mu+bandwidth )
 
-	def from_sample( self, points, weights=None ):
+	def from_sample( self, points, weights=None, inertia=0.0 ):
 		"""
-		Replace the points, training without inertia.
+		Replace the points, allowing for inertia if specified.
 		"""
 
-		self.points = numpy.array( points )
-
+		points = numpy.asarray( points )
 		n = len(points)
-		if weights:
-			self.weights = numpy.array(weights) / numpy.sum(weights)
-		else:
-			self.weights = numpy.ones( n ) / n 
 
-		self.parameters = [ self.points, self.parameters[1], self.weights ]
+		# Get the weights, or assign uniform weights
+		if weights:
+			weights = numpy.array(weights) / numpy.sum(weights)
+		else:
+			weights = numpy.ones( n ) / n 
+
+		# If no inertia, get rid of the previous points
+		if inertia == 0.0:
+			self.parameters[0] = points
+			self.parameters[2] = weights
+
+		# Otherwise adjust weights appropriately
+		else: 
+			self.parameters[0] = numpy.concatenate( ( self.parameters[0],
+													  points ) )
+			self.parameters[2] = numpy.concatenate( ( self.parameters[2]*inertia,
+													  weights*(1-inertia) ) )
 
 cdef class TriangleKernelDensity( Distribution ):
 	"""
@@ -1336,14 +1475,15 @@ cdef class TriangleKernelDensity( Distribution ):
 		Weights are scaled so that they sum to 1. 
 		"""
 
+		points = numpy.asarray( points )
 		n = len(points)
 		if weights:
-			self.weights = numpy.array(weights) / numpy.sum(weights)
+			weights = numpy.array(weights) / numpy.sum(weights)
 		else:
-			self.weights = numpy.ones( n ) / n 
+			weights = numpy.ones( n ) / n 
 
-		self.points = numpy.array( points )
-		self.parameters = [ self.points, bandwidth, self.weights ]
+		self.parameters = [ points, bandwidth, weights ]
+		self.summaries = []
 		self.name = "TriangleKernelDensity"
 
 	def log_probability( self, symbol ):
@@ -1387,24 +1527,35 @@ cdef class TriangleKernelDensity( Distribution ):
 		or uniformly if not, and then randomly sampling from that point's PDF.
 		"""
 
-		mu = numpy.random.choice( self.points, p=self.weights )
+		mu = numpy.random.choice( self.parameters[0], p=self.parameters[2] )
 		bandwidth = self.parameters[1]
 		return random.triangular( mu-bandwidth, mu+bandwidth, mu )
 
-	def from_sample( self, points, weights=None ):
+	def from_sample( self, points, weights=None, inertia=0.0 ):
 		"""
-		Replace the points, training without inertia.
+		Replace the points, allowing for inertia if specified.
 		"""
 
-		self.points = numpy.array( points )
-
+		points = numpy.asarray( points )
 		n = len(points)
-		if weights:
-			self.weights = numpy.array(weights) / numpy.sum(weights)
-		else:
-			self.weights = numpy.ones( n ) / n 
 
-		self.parameters = [ self.points, self.parameters[1], self.weights ]
+		# Get the weights, or assign uniform weights
+		if weights:
+			weights = numpy.array(weights) / numpy.sum(weights)
+		else:
+			weights = numpy.ones( n ) / n 
+
+		# If no inertia, get rid of the previous points
+		if inertia == 0.0:
+			self.parameters[0] = points
+			self.parameters[2] = weights
+
+		# Otherwise adjust weights appropriately
+		else: 
+			self.parameters[0] = numpy.concatenate( ( self.parameters[0],
+													  points ) )
+			self.parameters[2] = numpy.concatenate( ( self.parameters[2]*inertia,
+													  weights*(1-inertia) ) )
 
 cdef class MixtureDistribution( Distribution ):
 	"""
@@ -1421,11 +1572,11 @@ cdef class MixtureDistribution( Distribution ):
 		"""
 		n = len(distributions)
 		if weights:
-			self.weights = numpy.array( weights ) / numpy.sum( weights )
+			weights = numpy.array( weights ) / numpy.sum( weights )
 		else:
-			self.weights = numpy.ones(n) / n
+			weights = numpy.ones(n) / n
 
-		self.parameters = [ distributions, self.weights ]
+		self.parameters = [ distributions, weights ]
 		self.name = "MixtureDistribution"
 
 	def __str__( self ):
@@ -1527,16 +1678,37 @@ cdef class MultivariateDistribution( Distribution ):
 
 		return [ d.sample() for d in self.parameters[0] ]
 
-	def from_sample( self, items, weights=None ):
+	def from_sample( self, items, weights=None, inertia=0.0 ):
 		"""
 		Items are tuples, and so each distribution can be trained
 		independently of each other. 
 		"""
 
-		items = numpy.array( items )
+		items = numpy.asarray( items )
 
 		for i, d in enumerate( self.parameters[0] ):
-			d.from_sample( items[:,i], weights=weights )
+			d.from_sample( items[:,i], weights=weights, inertia=inertia )
+
+	def summarize( self, items, weights=None ):
+		"""
+		Take in an array of items and reduce it down to summary statistics. For
+		a multivariate distribution, this involves just passing the appropriate
+		data down to the appropriate distributions.
+		"""
+
+		items = numpy.asarray( items )
+
+		for i, d in enumerate( self.parameters[0] ):
+			d.summarize( items[:,i], weights=weights )
+
+	def from_summaries( self, inertia=0.0 ):
+		"""
+		Use the collected summary statistics in order to update the
+		distributions.
+		"""
+
+		for d in self.parameters[0]:
+			d.from_summaries( inertia=inertia )
 
 
 cdef class State(object):
@@ -3427,22 +3599,26 @@ cdef class Model(object):
 
 	def train( self, sequences, stop_threshold=1E-9, min_iterations=0,
 		max_iterations=None, algorithm='baum-welch', verbose=True,
-		transition_pseudocount=0, use_pseudocount=False, edge_inertia=0, 
-		emitted_probability_threshold=0, summaries=0 ):
+		transition_pseudocount=0, use_pseudocount=False, edge_inertia=0.0,
+		distribution_inertia=0.0 ):
 		"""
 		Given a list of sequences, performs re-estimation on the model
 		parameters. The two supported algorithms are "baum-welch" and
-		"viterbi," indicating their respective algorithm. Neither algorithm
-		makes use of inertia, meaning that the previous graph model is
-		thrown out and replaced with the one generated from the training
-		algorithm.
+		"viterbi," indicating their respective algorithm. 
+
+		Use either a uniform transition_pseudocount, or the
+		previously specified ones by toggling use_pseudocount if pseudocounts
+		are needed. edge_inertia can make the new edge parameters be a mix of
+		new parameters and the old ones, and distribution_inertia does the same
+		thing for distributions instead of transitions.
 
 		Baum-Welch: Iterates until the log of the "score" (total likelihood of 
 		all sequences) changes by less than stop_threshold. Returns the final 
 		log score.
 	
-		
-		Always trains for at least min_iterations.
+		Always trains for at least min_iterations, and terminate either when
+		reaching max_iterations, or the training improvement is smaller than
+		stop_threshold.
 
 		Viterbi: Training performed by running each sequence through the
 		viterbi decoding algorithm. Edge weight re-estimation is done by 
@@ -3473,7 +3649,7 @@ cdef class Model(object):
 				[self.log_probability( seq, path ) for seq, path in sequences])
 		
 			self._train_labelled( sequences, transition_pseudocount, 
-				use_pseudocount, edge_inertia )
+				use_pseudocount, edge_inertia, distribution_inertia )
 		else:
 			# Take the logsumexp of the log probabilities of the sequences.
 			# Since sequences is just a list of sequences now, we can map
@@ -3489,13 +3665,13 @@ cdef class Model(object):
 
 		if algorithm.lower() == 'viterbi':
 			self._train_viterbi( sequences, transition_pseudocount,
-				use_pseudocount, edge_inertia )
+				use_pseudocount, edge_inertia, distribution_inertia )
 
 		elif algorithm.lower() == 'baum-welch':
 			self._train_baum_welch( sequences, stop_threshold,
 				min_iterations, max_iterations, verbose, 
-				transition_pseudocount, use_pseudocount, edge_inertia, 
-				emitted_probability_threshold, summaries )
+				transition_pseudocount, use_pseudocount, edge_inertia,
+				distribution_inertia )
 
 		# If using the labeled training algorithm, then calculate the new
 		# probability sum across the path it chose, instead of the
@@ -3520,7 +3696,7 @@ cdef class Model(object):
 
 	def _train_baum_welch(self, sequences, stop_threshold, min_iterations, 
 		max_iterations, verbose, transition_pseudocount, use_pseudocount,
-		edge_inertia, emitted_probability_threshold, summaries ):
+		edge_inertia, distribution_inertia ):
 		"""
 		Given a list of sequences, perform Baum-Welch iterative re-estimation on
 		the model parameters.
@@ -3543,8 +3719,7 @@ cdef class Model(object):
 
 			# Perform an iteration of Baum-Welch training.
 			self._train_once_baum_welch( sequences, transition_pseudocount, 
-				use_pseudocount, edge_inertia, emitted_probability_threshold,
-				summaries )
+				use_pseudocount, edge_inertia, distribution_inertia )
 
 			# Increase the iteration counter by one.
 			iteration += 1
@@ -3566,8 +3741,8 @@ cdef class Model(object):
 				print( "Training improvement: {}".format(improvement) )
 			
 	cdef void _train_once_baum_welch(self, numpy.ndarray sequences, 
-		double transition_pseudocount, int use_pseudocount, double edge_inertia,
-		double emitted_probability_threshold, int summaries ):
+		double transition_pseudocount, int use_pseudocount, 
+		double edge_inertia, double distribution_inertia ):
 		"""
 		Implements one iteration of the Baum-Welch algorithm, as described in:
 		http://www.cs.cmu.edu/~durand/03-711/2006/Lectures/hmm-bw.pdf
@@ -3578,39 +3753,28 @@ cdef class Model(object):
 
 		cdef double [:,:] transition_log_probabilities 
 		cdef double [:,:] expected_transitions, e, f, b
-		cdef numpy.ndarray emitted_symbols
 		cdef double [:,:] emission_weights
 		cdef numpy.ndarray sequence
 		cdef double log_sequence_probability
-		cdef double equence_probability_sum
-		cdef int k, i, l, li, m = len( self.states ), n, observation=0, s
+		cdef double sequence_probability_sum
+		cdef int k, i, l, li, m = len( self.states ), n, observation=0
 		cdef int characters_so_far = 0
 		cdef object symbol
-		cdef double mean, variance, weight
 		cdef double [:] weights
 
 		cdef int [:] out_edges = self.out_edge_count
 		cdef int [:] in_edges = self.in_edge_count
+
+		# Define several helped variables.
+		cdef int [:] visited
+		cdef int [:] tied_states = self.tied_state_count
 
 		# Find the expected number of transitions between each pair of states, 
 		# given our data and our current parameters, but allowing the paths 
 		# taken to vary. (Indexed: from, to)
 		expected_transitions = numpy.zeros(( m, m ))
 
-		# We also need to keep a list of all emitted symbols, and a list of 
-		# weights for each state for each of those symbols.
-		# This is the concatenated list of emitted symbols
-		total_characters = 0
 		for sequence in sequences:
-			total_characters += len( sequence )
-
-		emitted_symbols = numpy.zeros( total_characters, dtype=type(sequences[0][0]) )
-
-		# This is a list lists of symbol weights, by state number, for 
-		# non-silent states
-		emission_weights = numpy.zeros(( self.silent_start, total_characters ))
-
-		for s, sequence in enumerate( sequences ):
 			n = len( sequence )
 			# Calculate the emission table
 			e = numpy.zeros(( n, self.silent_start )) 
@@ -3639,10 +3803,9 @@ cdef class Model(object):
 			# Fill in the backward DP matrix.
 			b = self.backward(sequence)
 
-			# Save the sequence in the running list of all emitted symbols
-			for i in xrange( n ):
-				emitted_symbols[characters_so_far+i] = sequence[i]
-
+			# Set the visited array to entirely 0s, meaning we haven't visited
+			# any states yet. 
+			visited = numpy.zeros( self.silent_start, dtype=numpy.int32 )
 			for k in xrange( m ):
 				# For each state we could have come from
 				for l in xrange( out_edges[k], out_edges[k+1] ):
@@ -3702,11 +3865,25 @@ cdef class Model(object):
 						log_sequence_probability )
 
 				if k < self.silent_start:
+					# If another state in the set of tied states has already
+					# been visited, we don't want to retrain.
+					if visited[k] == 1:
+						continue
+
+					# Mark that we've visited this state
+					visited[k] = 1
+
+					# Mark that we've visited all other states in this state
+					# group.
+					for l in xrange( tied_states[k], tied_states[k+1] ):
+						li = self.tied[l]
+						visited[li] = 1
+
 					# Now think about emission probabilities from this state
 					weights = numpy.zeros( n )
+
 					for i in xrange( n ):
 						# For each symbol that came out
-
 						# What's the weight of this symbol for that state?
 						# Probability that we emit index characters and then 
 						# transition to state l, and that from state l we  
@@ -3716,16 +3893,15 @@ cdef class Model(object):
 						# According to http://www1.icsi.berkeley.edu/Speech/
 						# docs/HTKBook/node7_mn.html, we really should divide by
 						# sequence probability.
-						weight = cexp(f[i+1, k] + b[i+1, k] - 
-							log_sequence_probability)
+						weights[i] = cexp( f[i+1, k] + b[i+1, k] - 
+							log_sequence_probability )
 						
-						# Add this weight to the weight list for this state
-						emission_weights[k, characters_so_far+i] = weight
-						weights[i] = weight
+						for l in xrange( tied_states[k], tied_states[k+1] ):
+							li = self.tied[l]
+							weights[i] += cexp( f[i+1, li] + b[i+1, li] -
+								log_sequence_probability )
 
 					self.states[k].distribution.summarize( sequence, weights )
-
-			characters_so_far += n
 
 		# We now have expected_transitions taking into account all sequences.
 		# And a list of all emissions, and a weighting of each emission for each
@@ -3773,20 +3949,21 @@ cdef class Model(object):
 						cexp( self.in_transition_log_probabilities[l] ) *
 						edge_inertia + probability * ( 1 - edge_inertia ) )
 
-		# Define several helped variables.
-		cdef double tied_state_probability
-		cdef int [:] visited = numpy.zeros( self.silent_start,
-			dtype=numpy.int32 )
-		cdef int [:] tied_states = self.tied_state_count
-		cdef list symbols, w
-
-		for k in xrange(self.silent_start):
+		visited = numpy.zeros( self.silent_start, dtype=numpy.int32 )
+		for k in xrange( self.silent_start ):
 			# If this distribution has already been trained because it is tied
 			# to an earlier state, don't bother retraining it as that would
 			# waste time.
 			if visited[k] == 1:
 				continue
+			
+			# Mark that we've visited this state
 			visited[k] = 1
+
+			# Mark that we've visited all states in this tied state group.
+			for l in xrange( tied_states[k], tied_states[k+1] ):
+				li = self.tied[l]
+				visited[li] = 1
 
 			# Re-estimate the emission distribution for every non-silent state.
 			# Take each emission weighted by the probability that we were in 
@@ -3794,40 +3971,12 @@ cdef class Model(object):
 			# sequence that the symbol was part of. Take into account tied
 			# states by only training that distribution one time, since many
 			# states are pointing to the same distribution object.
-			symbols = []
-			w = []
-
-			for i in xrange( total_characters ):
-				# Start off by assuming the probability for this character is
-				# the probability in the emitted_symbols list.
-				tied_state_probability = emission_weights[k, i]
-
-				# Go through and see if this symbol was emitted in any of the
-				# other states, and indicate they have all been visited.
-				for l in xrange( tied_states[k], tied_states[k+1] ):
-					li = self.tied[l]
-					tied_state_probability += emission_weights[li, i]
-					visited[li] = 1
-
-				# If the symbol was emitted by any of the states, then add it
-				# to the list of symbols used to train the underlying
-				# distribution.
-				if tied_state_probability > emitted_probability_threshold:
-					symbols.append( emitted_symbols[i] )
-					w.append( tied_state_probability )
-
-			# Now train this distribution on the symbols collected. If there
-			# are tied states, this will be done once per set of tied states
-			# in order to save time.
-			if summaries == 1:
-				self.states[k].distribution.from_summaries()
-			else:
-				self.states[k].distribution.from_sample( symbols, w )
-
+			self.states[k].distribution.from_summaries( 
+				inertia=distribution_inertia )
 
 	cdef void _train_viterbi( self, numpy.ndarray sequences, 
 		double transition_pseudocount, int use_pseudocount, 
-		double edge_inertia ):
+		double edge_inertia, double distribution_inertia ):
 		"""
 		Performs a simple viterbi training algorithm. Each sequence is tagged
 		using the viterbi algorithm, and both emissions and transitions are
@@ -3852,11 +4001,12 @@ cdef class Model(object):
 			sequence_path_pairs.append( (sequence, sequence_path) )
 
 		self._train_labelled( sequence_path_pairs, 
-			transition_pseudocount, use_pseudocount, edge_inertia )
+			transition_pseudocount, use_pseudocount, edge_inertia, 
+			distribution_inertia )
 
 	cdef void _train_labelled( self, list sequences,
 		double transition_pseudocount, int use_pseudocount,
-		double edge_inertia ):
+		double edge_inertia, double distribution_inertia ):
 		"""
 		Perform training on a set of sequences where the state path is known,
 		thus, labelled. Pass in a list of tuples, where each tuple is of the
@@ -3864,17 +4014,11 @@ cdef class Model(object):
 		"""
 
 		cdef int i, j, m=len(self.states), n, a, b, k, l, li
-		cdef int total_characters=0
 		cdef numpy.ndarray sequence 
 		cdef list labels
 		cdef State label
-		cdef list symbols = [ [] for i in xrange( self.silent_start ) ]
+		cdef list symbols = [ [] for i in xrange(m) ]
 		cdef int [:] tied_states = self.tied_state_count
-
-		# Get the total number of characters emitted by going through each
-		# sequence and getting the length
-		for sequence, labels in sequences:
-			total_characters += len( sequence )
 
 		# Define matrices for the transitions between states, and the weight of
 		# each emission for each state for training later.
@@ -3909,6 +4053,7 @@ cdef class Model(object):
 				# state.
 				k = indices[label]
 				symbols[k].append( sequence[i] )
+
 				# Also add the symbol to the list of symbols emitted from any
 				# tied states to the current state.
 				for l in xrange( tied_states[k], tied_states[k+1] ):
@@ -3960,7 +4105,7 @@ cdef class Model(object):
 		cdef int [:] visited = numpy.zeros( self.silent_start,
 			dtype=numpy.int32 )
 
-		for k in xrange(self.silent_start):
+		for k in xrange( self.silent_start ):
 			# If this distribution has already been trained because it is tied
 			# to an earlier state, don't bother retraining it as that would
 			# waste time.
@@ -3978,4 +4123,5 @@ cdef class Model(object):
 			# Now train this distribution on the symbols collected. If there
 			# are tied states, this will be done once per set of tied states
 			# in order to save time.
-			self.states[k].distribution.from_sample( symbols[k] )
+			self.states[k].distribution.from_sample( symbols[k], 
+				inertia=distribution_inertia )


### PR DESCRIPTION
v1.0.1a, 8/26/2014 --
(1) Distribution inertia added for all distributions. This means that
parameters for the distributions are updated to be
inertia_prior_parameters + (1-inertia)_new_parameters. This can be
triggered using `distribution_inertia` in the
`Model.train` method. #27 closed.

(2) Summary statistics implemented for Baum-Welch training. This
involves summarizing one sequence at a time and storing
the appropriate summary statistics to the distribution object using
`Distribution.summarize( items, weights )`, and then
updating the parameters using these summary statistics and an
appropriate inertia with `Distribution.from_summarize(
inertia=0.0 )`. This makes training on large numbers of sequences always
faster, but training on small numbers of long
sequences take slightly longer. #34 closed.

(3) Nosetests significantly expanded to include more tests. This
includes a new file `test_training.py`, which has a
large number of tests on the Viterbi and Baum-Welch training algorithms,
with different parameters. This also includes
expanded testing of each distribution, and each of the training
functions for that sample.
