### PR TITLE
Revert "Making chenges for python3 compatibility. "

### DIFF
--- a/tests/test_profile_model.py
+++ b/tests/test_profile_model.py
@@ -101,7 +101,7 @@ def test_same_length_viterbi():
 
 	scores = [ -0.5132449003570658, -11.048101241343396, -9.125519674022627, 
 		-5.0879558788604475 ]
-	sequences = [ list(x) for x in [ 'ACT', 'GGC', 'GAT', 'ACC' ] ]
+	sequences = map( list, [ 'ACT', 'GGC', 'GAT', 'ACC' ] )
 	
 	for seq, score in zip( sequences, scores ):
 		assert model.viterbi( seq )[0] == score, \
@@ -120,8 +120,8 @@ def test_variable_length_viterbi():
 	scores = [ -5.406181012423981, -10.88681993576597, -3.6244718790494277, 
 	-3.644880750680635, -10.674332964640293, -10.393824835172445, 
 	-8.67126440174503, -16.903451796110275, -16.451699654050792 ]
-	sequences = [ list(x) for x in ('A', 'GA', 'AC', 'AT', 'ATCC', 
-		'ACGTG', 'ATTT', 'TACCCTC', 'TGTCAACACT') ]
+	sequences = map( list, ('A', 'GA', 'AC', 'AT', 'ATCC', 
+		'ACGTG', 'ATTT', 'TACCCTC', 'TGTCAACACT') )
 
 	for seq, score in zip( sequences, scores ):
 		assert model.viterbi( seq )[0] == score, \
@@ -135,7 +135,7 @@ def test_log_probability():
 	'''
 
 	scores = [ -5.3931, -0.5052, -11.8478, -14.3482 ]
-	sequences = [ list(x) for x in ( 'A', 'ACT', 'GGCA', 'TACCTGT' ) ]
+	sequences = map( list, ( 'A', 'ACT', 'GGCA', 'TACCTGT' ) )
 
 	for seq, score in zip( sequences, scores ):
 		print( round( model.log_probability( seq ), 4 ) )
@@ -152,7 +152,7 @@ def test_posterior_transitions():
 	a_scores = [ 0.0, 0.0021, 0.2017, 1.5105 ]
 	b_scores = [ 0.013, 0.0035, 0.817, 0.477 ]
 	t_scores = [ 4.013, 4.0083, 6.457, 8.9812 ]
-	sequences = [ list(x) for x in ( 'A', 'ACT', 'GGCA', 'TACCTGT' ) ]
+	sequences = map( list, ( 'A', 'ACT', 'GGCA', 'TACCTGT' ) )
 
 	indices = { state.name: i for i, state in enumerate( model.states ) }
 	i, j = indices['I2'], indices['D1']
@@ -177,7 +177,7 @@ def test_posterior_emissions():
 	a_scores = [ 0.987, 0.9965, 0.183, 0.523 ]
 	b_scores = [ 0.0, 0.9977, 0.7364, 0.6318 ]
 	c_scores = [ 0.0, 0.9975, 0.6237, 0.8641 ]
-	sequences = [ list(x) for x in ( 'A', 'ACT', 'GGCA', 'TACCTGT' ) ]
+	sequences = map( list, ( 'A', 'ACT', 'GGCA', 'TACCTGT' ) )
 
 	indices = { state.name: i for i, state in enumerate( model.states ) }
 	i, j, k = indices['M1'], indices['M2'], indices['M3']

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -100,9 +100,9 @@ def test_viterbi_train():
 	Test the model using various parameter settings for Viterbi training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='viterbi', 
@@ -117,9 +117,9 @@ def test_viterbi_train_no_pseudocount():
 	Test the model using various parameter settings for Viterbi training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='viterbi', 
@@ -134,9 +134,9 @@ def test_viterbi_train_w_pseudocount():
 	Test the model using various parameter settings for Viterbi training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='viterbi', 
@@ -151,9 +151,9 @@ def test_viterbi_train_w_pseudocount_priors():
 	Test the model using various parameter settings for Viterbi training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='viterbi', 
@@ -169,9 +169,9 @@ def test_viterbi_train_w_inertia():
 	Test the model using various parameter settings for Viterbi training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='viterbi', 
@@ -186,9 +186,9 @@ def test_viterbi_train_w_inertia2():
 	Test the model using various parameter settings for Viterbi training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='viterbi', 
@@ -203,9 +203,9 @@ def test_viterbi_train_w_pseudocount_inertia():
 	Test the model using various parameter settings for Viterbi training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='viterbi', 
@@ -221,9 +221,9 @@ def test_bw_train():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 
@@ -239,9 +239,9 @@ def test_bw_train_no_pseudocount():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 
@@ -257,9 +257,9 @@ def test_bw_train_w_pseudocount():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 
@@ -275,9 +275,9 @@ def test_bw_train_w_pseudocount_priors():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 
@@ -294,9 +294,9 @@ def test_bw_train_w_inertia():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 
@@ -312,9 +312,9 @@ def test_bw_train_w_inertia2():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 
@@ -330,9 +330,9 @@ def test_bw_train_w_pseudocount_inertia():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 
@@ -349,9 +349,9 @@ def test_bw_train_w_frozen_distributions():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 
@@ -367,9 +367,9 @@ def test_bw_train_w_frozen_edges():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 
@@ -385,9 +385,9 @@ def test_bw_train_w_edge_a_distribution_inertia():
 	Test the model using various parameter settings for Baum-Welch training.
 	'''
 
-	seqs = [ list(x) for x in [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
+	seqs = map( list, [ 'ACT', 'ACT', 'ACC', 'ACTC', 'ACT', 'ACT', 'CCT', 
 		'CCC', 'AAT', 'CT', 'AT', 'CT', 'CT', 'CT', 'CT', 'CT', 'CT', 
-		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] ]
+		'ACT', 'ACT', 'CT', 'ACT', 'CT', 'CT', 'CT', 'CT' ] )
 
 	total_improvement = model.train( seqs, 
 									 algorithm='baum-welch', 

--- a/yahmm/__init__.py
+++ b/yahmm/__init__.py
@@ -10,20 +10,16 @@ import numpy as np
 import os
 import pyximport
 
-# Make our dependencies explicit so compiled Cython code won't segfault trying
-# to load them.
-import networkx, matplotlib, numpy
-
 # Adapted from Cython docs https://github.com/cython/cython/wiki/
 # InstallingOnWindows#mingw--numpy--pyximport-at-runtime
 if os.name == 'nt':
-    if 'CPATH' in os.environ:
+    if os.environ.has_key('CPATH'):
         os.environ['CPATH'] = os.environ['CPATH'] + np.get_include()
     else:
         os.environ['CPATH'] = np.get_include()
 
     # XXX: we're assuming that MinGW is installed in C:\MinGW (default)
-    if 'PATH' in os.environ:
+    if os.environ.has_key('PATH'):
         os.environ['PATH'] = os.environ['PATH'] + ';C:\MinGW\bin'
     else:
         os.environ['PATH'] = 'C:\MinGW\bin'
@@ -32,7 +28,7 @@ if os.name == 'nt':
     pyximport.install(setup_args=mingw_setup_args)
 
 elif os.name == 'posix':
-    if 'CFLAGS' in os.environ:
+    if os.environ.has_key('CFLAGS'):
         os.environ['CFLAGS'] = os.environ['CFLAGS'] + ' -I' + np.get_include()
     else:
         os.environ['CFLAGS'] = ' -I' + np.get_include()

--- a/yahmm/yahmm.pyx
+++ b/yahmm/yahmm.pyx
@@ -14,14 +14,6 @@ import math, random, itertools as it, sys, bisect
 import networkx
 import scipy.stats, scipy.sparse, scipy.special
 
-if sys.version_info[0] > 2:
-	# Set up for Python 3
-	from functools import reduce
-	xrange = range
-	izip = zip
-else:
-	izip = it.izip
-
 import numpy
 cimport numpy
 
@@ -251,7 +243,7 @@ cdef class UniformDistribution( Distribution ):
 		
 		if weights is not None:
 			# Throw out items with weight 0
-			items = [item for (item, weight) in izip(items, weights) 
+			items = [item for (item, weight) in it.izip(items, weights) 
 				if weight > 0]
 		
 		if len(items) == 0:
@@ -275,7 +267,7 @@ cdef class UniformDistribution( Distribution ):
 
 		if weights is not None:
 			# Throw out items with weight 0
-			items = [ item for item, weight in izip( items, weights )
+			items = [ item for item, weight in it.izip( items, weights )
 				if weight > 0 ]
 
 		if len( items ) == 0:
@@ -572,7 +564,7 @@ cdef class LogNormalDistribution( Distribution ):
 		# 1 being to ignore new training data.
 		prior_mean, prior_std = self.parameters
 		self.parameters = [ prior_mean*inertia + mean*(1-inertia), 
-							prior_std*inertia + std*(1-inertia) ]
+						    prior_std*inertia + std*(1-inertia) ]
 
 	def summarize( self, items, weights=None ):
 		'''
@@ -628,7 +620,7 @@ cdef class LogNormalDistribution( Distribution ):
 		# of 0 being completely replacing the parameters, and an inertia of
 		# 1 being to ignore new training data.
 		self.parameters = [ prior_mean*inertia + mean*(1-inertia), 
-							prior_std*inertia + std*(1-inertia) ]
+						    prior_std*inertia + std*(1-inertia) ]
 		self.summaries = []
 
 cdef class ExtremeValueDistribution( Distribution ):
@@ -1174,7 +1166,7 @@ cdef class DiscreteDistribution(Distribution):
 
 		# Sum the weights seen for each character
 		characters = {}
-		for character, weight in izip( items, weights ):
+		for character, weight in it.izip( items, weights ):
 			try:
 				characters[character] += weight
 			except KeyError:
@@ -1207,7 +1199,7 @@ cdef class DiscreteDistribution(Distribution):
 			weights = numpy.asarray( weights )
 
 		characters = self.summaries[0]
-		for character, weight in izip( items, weights ):
+		for character, weight in it.izip( items, weights ):
 			try:
 				characters[character] += weight
 			except KeyError:
@@ -2081,8 +2073,8 @@ cdef class Model(object):
 		for state in self.graph.nodes():
 
 			# Perform log sum exp on the edges to see if they properly sum to 1
-			out_edges = round( sum( numpy.e**x['weight'] 
-				for x in self.graph.edge[state].values() ), 8 )
+			out_edges = round( numpy.sum( map( lambda x: numpy.e**x['weight'], 
+				self.graph.edge[state].values() ) ), 8 )
 
 			# The end state has no out edges, so will be 0
 			if out_edges != 1. and state != self.end:
@@ -2276,9 +2268,9 @@ cdef class Model(object):
 
 		# Take the cumulative sum so that we can associat
 		self.in_edge_count = numpy.cumsum(self.in_edge_count, 
-			dtype=numpy.int32)
+            dtype=numpy.int32)
 		self.out_edge_count = numpy.cumsum(self.out_edge_count, 
-			dtype=numpy.int32 )
+            dtype=numpy.int32 )
 
 		# Now we go through the edges again in order to both fill in the
 		# transition probability matrix, and also to store the indices sorted
@@ -3578,7 +3570,7 @@ cdef class Model(object):
 
 		# Build state objects for every state with the appropriate distribution
 		states = [ State( distribution, name=name ) for name, distribution in
-			izip( state_names, distributions) ]
+			it.izip( state_names, distributions) ]
 
 		n = len( states )
 


### PR DESCRIPTION
Reverts jmschrei/yahmm#35

Travis doesn't work on python 3.2 with these tests.

```
Using worker: worker-linux-2-1.bb.travis-ci.org:travis-linux-3
git.1
0.66s$ git clone --depth=50 --branch=master git://github.com/jmschrei/yahmm.git jmschrei/yahmm
Cloning into 'jmschrei/yahmm'...
remote: Counting objects: 344, done.
remote: Compressing objects: 100% (196/196), done.
remote: Total 344 (delta 166), reused 313 (delta 138)
Receiving objects: 100% (344/344), 6.76 MiB | 0 bytes/s, done.
Resolving deltas: 100% (166/166), done.
Checking connectivity... done.
$ cd jmschrei/yahmm
git.4
$ git checkout -qf b75f5f6e11b5a7164de192236e6ca8ac769e46d9
0.01s$ source ~/virtualenv/python3.2_with_system_site_packages/bin/activate
0.01s$ python --version
Python 3.2.3
0.37s$ pip --version
pip 1.5.4 from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages (python 3.2)
before_install
19.20s$ sudo apt-get install -qq python-numpy python-scipy
Selecting previously unselected package libamd2.2.0.
(Reading database ... 71590 files and directories currently installed.)
Unpacking libamd2.2.0 (from .../libamd2.2.0_1%3a3.4.0-2ubuntu3_amd64.deb) ...
Selecting previously unselected package libumfpack5.4.0.
Unpacking libumfpack5.4.0 (from .../libumfpack5.4.0_1%3a3.4.0-2ubuntu3_amd64.deb) ...
Selecting previously unselected package python-imaging.
Unpacking python-imaging (from .../python-imaging_1.1.7-4ubuntu0.12.04.1_amd64.deb) ...
Selecting previously unselected package python-numpy.
Unpacking python-numpy (from .../python-numpy_1%3a1.6.1-6ubuntu1_amd64.deb) ...
Selecting previously unselected package python-scipy.
Unpacking python-scipy (from .../python-scipy_0.9.0+dfsg1-1ubuntu2_amd64.deb) ...
Processing triggers for man-db ...
Setting up libamd2.2.0 (1:3.4.0-2ubuntu3) ...
Setting up libumfpack5.4.0 (1:3.4.0-2ubuntu3) ...
Setting up python-imaging (1.1.7-4ubuntu0.12.04.1) ...
Setting up python-numpy (1:1.6.1-6ubuntu1) ...
Setting up python-scipy (0.9.0+dfsg1-1ubuntu2) ...
Processing triggers for libc-bin ...
ldconfig deferred processing now taking place
install
373.96s$ pip install -r requirements.txt
Downloading/unpacking Cython==0.20.1 (from -r requirements.txt (line 1))
  Downloading Cython-0.20.1.tar.gz (2.6MB): 2.6MB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/setup.py) egg_info for package Cython

    warning: no files found matching '*.pyx' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.pxd' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.h' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.pxd' under directory 'Cython/Utility'
Downloading/unpacking matplotlib==1.3.1 (from -r requirements.txt (line 2))
  Downloading matplotlib-1.3.1.tar.gz (42.7MB): 42.7MB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2_with_system_site_packages/build/matplotlib/setup.py) egg_info for package matplotlib
    ============================================================================
    Edit setup.cfg to change the build options

    BUILDING MATPLOTLIB
                matplotlib: yes [1.3.1]
                    python: yes [3.2.3 (default, Feb 27 2014, 21:31:18)  [GCC
                            4.6.3]]
                  platform: yes [linux2]

    REQUIRED DEPENDENCIES AND EXTENSIONS
                     numpy: yes [version 1.8.2]
                  dateutil: yes [dateutil was not found. It is required for date
                            axis support. pip/easy_install may attempt to
                            install it after matplotlib.]
                   tornado: yes [tornado was not found. It is required for the
                            WebAgg backend. pip/easy_install may attempt to
                            install it after matplotlib.]
                 pyparsing: yes [pyparsing was not found. It is required for
                            mathtext support. pip/easy_install may attempt to
                            install it after matplotlib.]
                     pycxx: yes [Official versions of PyCXX are not compatible
                            with Python 3.x.  Using local copy]
                    libagg: yes [pkg-config information for 'libagg' could not
                            be found. Using local copy.]
                  freetype: yes [version 14.0.8]
                       png: yes [version 1.2.46]

    OPTIONAL SUBPACKAGES
               sample_data: yes [installing]
                  toolkits: yes [installing]
                     tests: yes [using nose version 1.3.4]

    OPTIONAL BACKEND EXTENSIONS
                    macosx: no  [Mac OS-X only]
                    qt4agg: no  [PyQt4 not found]
                   gtk3agg: no  [Can't build with Travis]
                 gtk3cairo: no  [Can't build with Travis]
                    gtkagg: no  [Requires pygtk]
                     tkagg: no  [TKAgg requires Tkinter.]
                     wxagg: no  [requires wxPython]
                       gtk: no  [Requires pygtk]
                       agg: yes [installing]
                     cairo: no  [cairo not found]
                 windowing: no  [Microsoft Windows only]

    OPTIONAL LATEX DEPENDENCIES
                    dvipng: no
               ghostscript: yes [version 9.05]
                     latex: no
                   pdftops: no


Downloading/unpacking networkx==1.8.1 (from -r requirements.txt (line 3))
  Downloading networkx-1.8.1.tar.gz (806kB): 806kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2_with_system_site_packages/build/networkx/setup.py) egg_info for package networkx

    warning: no files found matching 'scripts/*'
    warning: no files found matching 'networkx/tests/*.txt'
    warning: no files found matching 'networkx/*/*/tests/*.txt'
    warning: no previously-included files matching '*~' found anywhere in distribution
    warning: no previously-included files matching '*.pyc' found anywhere in distribution
    warning: no previously-included files matching '.svn' found anywhere in distribution
    no previously-included directories found matching 'doc/build'
    no previously-included directories found matching 'doc/source/reference/generated'
    no previously-included directories found matching 'doc/source/examples'
    no previously-included directories found matching 'doc/source/static/examples'
    no previously-included directories found matching 'doc/source/templates/gallery.html'
Downloading/unpacking nose==1.3.3 (from -r requirements.txt (line 4))
  Downloading nose-1.3.3.tar.gz (274kB): 274kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2_with_system_site_packages/build/nose/setup.py) egg_info for package nose

    no previously-included directories found matching 'doc/.build'
Requirement already satisfied (use --upgrade to upgrade): numpy>=1.5 in /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages (from matplotlib==1.3.1->-r requirements.txt (line 2))
Downloading/unpacking python-dateutil (from matplotlib==1.3.1->-r requirements.txt (line 2))
  Downloading python-dateutil-2.2.tar.gz (259kB): 259kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2_with_system_site_packages/build/python-dateutil/setup.py) egg_info for package python-dateutil

Downloading/unpacking tornado (from matplotlib==1.3.1->-r requirements.txt (line 2))
  Downloading tornado-4.0.1.tar.gz (314kB): 314kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2_with_system_site_packages/build/tornado/setup.py) egg_info for package tornado

Downloading/unpacking pyparsing>=1.5.6,!=2.0.0 (from matplotlib==1.3.1->-r requirements.txt (line 2))
  Downloading pyparsing-2.0.2.tar.gz (1.1MB): 1.1MB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2_with_system_site_packages/build/pyparsing/setup.py) egg_info for package pyparsing

Downloading/unpacking six (from python-dateutil->matplotlib==1.3.1->-r requirements.txt (line 2))
  Downloading six-1.7.3-py2.py3-none-any.whl
Downloading/unpacking certifi (from tornado->matplotlib==1.3.1->-r requirements.txt (line 2))
  Downloading certifi-14.05.14.tar.gz (168kB): 168kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python3.2_with_system_site_packages/build/certifi/setup.py) egg_info for package certifi

Installing collected packages: Cython, matplotlib, networkx, nose, python-dateutil, tornado, pyparsing, six, certifi
  Running setup.py install for Cython
    Skipping implicit fixer: buffer
    Skipping implicit fixer: idioms
    Skipping implicit fixer: set_literal
    Skipping implicit fixer: ws_comma
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Plex/Scanners.c' Cython extension (up-to-date)
    building 'Cython.Plex.Scanners' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Plex/Scanners.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Plex/Scanners.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Plex/Scanners.o -o build/lib.linux-x86_64-3.2/Cython/Plex/Scanners.cpython-32mu.so
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Plex/Actions.c' Cython extension (up-to-date)
    building 'Cython.Plex.Actions' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Plex/Actions.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Plex/Actions.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Plex/Actions.o -o build/lib.linux-x86_64-3.2/Cython/Plex/Actions.cpython-32mu.so
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Lexicon.c' Cython extension (up-to-date)
    building 'Cython.Compiler.Lexicon' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Lexicon.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Lexicon.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Lexicon.o -o build/lib.linux-x86_64-3.2/Cython/Compiler/Lexicon.cpython-32mu.so
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Scanning.c' Cython extension (up-to-date)
    building 'Cython.Compiler.Scanning' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Scanning.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Scanning.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Scanning.o -o build/lib.linux-x86_64-3.2/Cython/Compiler/Scanning.cpython-32mu.so
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Parsing.c' Cython extension (up-to-date)
    building 'Cython.Compiler.Parsing' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Parsing.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Parsing.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Parsing.o -o build/lib.linux-x86_64-3.2/Cython/Compiler/Parsing.cpython-32mu.so
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Visitor.c' Cython extension (up-to-date)
    building 'Cython.Compiler.Visitor' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Visitor.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Visitor.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Visitor.o -o build/lib.linux-x86_64-3.2/Cython/Compiler/Visitor.cpython-32mu.so
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/FlowControl.c' Cython extension (up-to-date)
    building 'Cython.Compiler.FlowControl' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/FlowControl.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/FlowControl.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/FlowControl.o -o build/lib.linux-x86_64-3.2/Cython/Compiler/FlowControl.cpython-32mu.so
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Code.c' Cython extension (up-to-date)
    building 'Cython.Compiler.Code' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Code.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Code.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Compiler/Code.o -o build/lib.linux-x86_64-3.2/Cython/Compiler/Code.cpython-32mu.so
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Runtime/refnanny.c' Cython extension (up-to-date)
    building 'Cython.Runtime.refnanny' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Runtime/refnanny.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Runtime/refnanny.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Runtime/refnanny.o -o build/lib.linux-x86_64-3.2/Cython/Runtime/refnanny.cpython-32mu.so
    skipping '/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Tempita/_tempita.c' Cython extension (up-to-date)
    building 'Cython.Tempita._tempita' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c /home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Tempita/_tempita.c -o build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Tempita/_tempita.o
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/home/travis/virtualenv/python3.2_with_system_site_packages/build/Cython/Cython/Tempita/_tempita.o -o build/lib.linux-x86_64-3.2/Cython/Tempita/_tempita.cpython-32mu.so

    warning: no files found matching '*.pyx' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.pxd' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.h' under directory 'Cython/Debugger/Tests'
    warning: no files found matching '*.pxd' under directory 'Cython/Utility'
    Installing cython script to /home/travis/virtualenv/python3.2_with_system_site_packages/bin
    Installing cygdb script to /home/travis/virtualenv/python3.2_with_system_site_packages/bin
  Running setup.py install for matplotlib
    ============================================================================
    Edit setup.cfg to change the build options

    BUILDING MATPLOTLIB
                matplotlib: yes [1.3.1]
                    python: yes [3.2.3 (default, Feb 27 2014, 21:31:18)  [GCC
                            4.6.3]]
                  platform: yes [linux2]

    REQUIRED DEPENDENCIES AND EXTENSIONS
                     numpy: yes [version 1.8.2]
                  dateutil: yes [dateutil was not found. It is required for date
                            axis support. pip/easy_install may attempt to
                            install it after matplotlib.]
                   tornado: yes [tornado was not found. It is required for the
                            WebAgg backend. pip/easy_install may attempt to
                            install it after matplotlib.]
                 pyparsing: yes [pyparsing was not found. It is required for
                            mathtext support. pip/easy_install may attempt to
                            install it after matplotlib.]
                     pycxx: yes [Official versions of PyCXX are not compatible
                            with Python 3.x.  Using local copy]
                    libagg: yes [pkg-config information for 'libagg' could not
                            be found. Using local copy.]
                  freetype: yes [version 14.0.8]
                       png: yes [version 1.2.46]

    OPTIONAL SUBPACKAGES
               sample_data: yes [installing]
                  toolkits: yes [installing]
                     tests: yes [using nose version 1.3.4]

    OPTIONAL BACKEND EXTENSIONS
                    macosx: no  [Mac OS-X only]
                    qt4agg: no  [PyQt4 not found]
                   gtk3agg: no  [Can't build with Travis]
                 gtk3cairo: no  [Can't build with Travis]
                    gtkagg: no  [Requires pygtk]
                     tkagg: no  [TKAgg requires Tkinter.]
                     wxagg: no  [requires wxPython]
                       gtk: no  [Requires pygtk]
                       agg: yes [installing]
                     cairo: no  [cairo not found]
                 windowing: no  [Microsoft Windows only]

    OPTIONAL LATEX DEPENDENCIES
                    dvipng: no
               ghostscript: yes [version 9.05]
                     latex: no
                   pdftops: no

    Fixing build/lib.linux-x86_64-3.2/pylab.py build/lib.linux-x86_64-3.2/matplotlib/offsetbox.py build/lib.linux-x86_64-3.2/matplotlib/_cm.py build/lib.linux-x86_64-3.2/matplotlib/patheffects.py build/lib.linux-x86_64-3.2/matplotlib/path.py build/lib.linux-x86_64-3.2/matplotlib/mpl.py build/lib.linux-x86_64-3.2/matplotlib/texmanager.py build/lib.linux-x86_64-3.2/matplotlib/scale.py build/lib.linux-x86_64-3.2/matplotlib/spines.py build/lib.linux-x86_64-3.2/matplotlib/_pylab_helpers.py build/lib.linux-x86_64-3.2/matplotlib/mlab.py build/lib.linux-x86_64-3.2/matplotlib/fontconfig_pattern.py build/lib.linux-x86_64-3.2/matplotlib/patches.py build/lib.linux-x86_64-3.2/matplotlib/bezier.py build/lib.linux-x86_64-3.2/matplotlib/image.py build/lib.linux-x86_64-3.2/matplotlib/stackplot.py build/lib.linux-x86_64-3.2/matplotlib/__init__.py build/lib.linux-x86_64-3.2/matplotlib/rcsetup.py build/lib.linux-x86_64-3.2/matplotlib/sankey.py build/lib.linux-x86_64-3.2/matplotlib/transforms.py build/lib.linux-x86_64-3.2/matplotlib/streamplot.py build/lib.linux-x86_64-3.2/matplotlib/ticker.py build/lib.linux-x86_64-3.2/matplotlib/axis.py build/lib.linux-x86_64-3.2/matplotlib/pyplot.py build/lib.linux-x86_64-3.2/matplotlib/text.py build/lib.linux-x86_64-3.2/matplotlib/cm.py build/lib.linux-x86_64-3.2/matplotlib/colors.py build/lib.linux-x86_64-3.2/matplotlib/table.py build/lib.linux-x86_64-3.2/matplotlib/collections.py build/lib.linux-x86_64-3.2/matplotlib/dviread.py build/lib.linux-x86_64-3.2/matplotlib/units.py build/lib.linux-x86_64-3.2/matplotlib/blocking_input.py build/lib.linux-x86_64-3.2/matplotlib/_mathtext_data.py build/lib.linux-x86_64-3.2/matplotlib/quiver.py build/lib.linux-x86_64-3.2/matplotlib/textpath.py build/lib.linux-x86_64-3.2/matplotlib/cbook.py build/lib.linux-x86_64-3.2/matplotlib/pylab.py build/lib.linux-x86_64-3.2/matplotlib/tight_bbox.py build/lib.linux-x86_64-3.2/matplotlib/type1font.py build/lib.linux-x86_64-3.2/matplotlib/axes.py build/lib.linux-x86_64-3.2/matplotlib/mathtext.py build/lib.linux-x86_64-3.2/matplotlib/backend_bases.py build/lib.linux-x86_64-3.2/matplotlib/artist.py build/lib.linux-x86_64-3.2/matplotlib/hatch.py build/lib.linux-x86_64-3.2/matplotlib/widgets.py build/lib.linux-x86_64-3.2/matplotlib/container.py build/lib.linux-x86_64-3.2/matplotlib/docstring.py build/lib.linux-x86_64-3.2/matplotlib/font_manager.py build/lib.linux-x86_64-3.2/matplotlib/animation.py build/lib.linux-x86_64-3.2/matplotlib/legend_handler.py build/lib.linux-x86_64-3.2/matplotlib/lines.py build/lib.linux-x86_64-3.2/matplotlib/figure.py build/lib.linux-x86_64-3.2/matplotlib/afm.py build/lib.linux-x86_64-3.2/matplotlib/finance.py build/lib.linux-x86_64-3.2/matplotlib/tight_layout.py build/lib.linux-x86_64-3.2/matplotlib/gridspec.py build/lib.linux-x86_64-3.2/matplotlib/dates.py build/lib.linux-x86_64-3.2/matplotlib/contour.py build/lib.linux-x86_64-3.2/matplotlib/markers.py build/lib.linux-x86_64-3.2/matplotlib/legend.py build/lib.linux-x86_64-3.2/matplotlib/colorbar.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_wxagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtk3cairo.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_pgf.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_cairo.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_cocoaagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/qt4_compat.py build/lib.linux-x86_64-3.2/matplotlib/backends/__init__.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtk3agg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gdk.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_ps.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_pdf.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_qt4agg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_mixed.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_template.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtk.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_qt4.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_webagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/tkagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtkcairo.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_svg.py build/lib.linux-x86_64-3.2/matplotlib/backends/windowing.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_tkagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_wx.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_agg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtkagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_macosx.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtk3.py build/lib.linux-x86_64-3.2/matplotlib/backends/qt4_editor/formlayout.py build/lib.linux-x86_64-3.2/matplotlib/backends/qt4_editor/__init__.py build/lib.linux-x86_64-3.2/matplotlib/backends/qt4_editor/figureoptions.py build/lib.linux-x86_64-3.2/matplotlib/compat/__init__.py build/lib.linux-x86_64-3.2/matplotlib/compat/subprocess.py build/lib.linux-x86_64-3.2/matplotlib/projections/__init__.py build/lib.linux-x86_64-3.2/matplotlib/projections/polar.py build/lib.linux-x86_64-3.2/matplotlib/projections/geo.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/plot_directive.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/__init__.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/ipython_directive.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/ipython_console_highlighting.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/mathmpl.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/only_directives.py build/lib.linux-x86_64-3.2/matplotlib/testing/__init__.py build/lib.linux-x86_64-3.2/matplotlib/testing/compare.py build/lib.linux-x86_64-3.2/matplotlib/testing/noseclasses.py build/lib.linux-x86_64-3.2/matplotlib/testing/image_util.py build/lib.linux-x86_64-3.2/matplotlib/testing/decorators.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/__init__.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/UnitDblConverter.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/EpochConverter.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/UnitDbl.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/Duration.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/StrConverter.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/UnitDblFormatter.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/Epoch.py build/lib.linux-x86_64-3.2/matplotlib/tri/tritools.py build/lib.linux-x86_64-3.2/matplotlib/tri/triplot.py build/lib.linux-x86_64-3.2/matplotlib/tri/triangulation.py build/lib.linux-x86_64-3.2/matplotlib/tri/__init__.py build/lib.linux-x86_64-3.2/matplotlib/tri/trifinder.py build/lib.linux-x86_64-3.2/matplotlib/tri/trirefine.py build/lib.linux-x86_64-3.2/matplotlib/tri/triinterpolate.py build/lib.linux-x86_64-3.2/matplotlib/tri/tricontour.py build/lib.linux-x86_64-3.2/matplotlib/tri/tripcolor.py build/lib.linux-x86_64-3.2/matplotlib/delaunay/__init__.py build/lib.linux-x86_64-3.2/matplotlib/delaunay/triangulate.py build/lib.linux-x86_64-3.2/matplotlib/delaunay/testfuncs.py build/lib.linux-x86_64-3.2/matplotlib/delaunay/interpolate.py build/lib.linux-x86_64-3.2/mpl_toolkits/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/gtktools.py build/lib.linux-x86_64-3.2/mpl_toolkits/exceltools.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/axes3d.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/proj3d.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/art3d.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/axis3d.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axes_divider.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/floating_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/grid_finder.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/angle_helper.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axes_grid.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/grid_helper_curvelinear.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/clip_path.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axislines.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/parasite_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axisline_style.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axes_size.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/inset_locator.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axes_rgb.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/anchored_artists.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axis_artist.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/colorbar.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/axes_divider.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/axes_grid.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/parasite_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/mpl_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/axes_size.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/inset_locator.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/axes_rgb.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/anchored_artists.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/colorbar.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/floating_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/grid_finder.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/angle_helper.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/grid_helper_curvelinear.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/clip_path.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/axislines.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/axisline_style.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/axis_artist.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_basic.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_contour.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_image.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_mlab.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_dates.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_legend.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_cbook.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_axes.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_dviread.py build/lib.linux-x86_64-3.2/matplotlib/tests/__init__.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_triangulation.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_path.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_patches.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_text.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_coding_standards.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_spines.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_table.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_backend_pdf.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_delaunay.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_ticker.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_artist.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_colorbar.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_png.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_simplification.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_transforms.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_pickle.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_figure.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_bbox_tight.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_animation.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_collections.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_streamplot.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_backend_qt4.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_compare_images.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_backend_svg.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_backend_pgf.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_patheffects.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_sankey.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_scale.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_mathtext.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_lines.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_tightlayout.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_ttconv.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_colors.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_subplots.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_rcparams.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_arrow_patches.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_agg.py
    Skipping implicit fixer: buffer
    Skipping implicit fixer: idioms
    Skipping implicit fixer: set_literal
    Skipping implicit fixer: ws_comma
    Fixing build/lib.linux-x86_64-3.2/pylab.py build/lib.linux-x86_64-3.2/matplotlib/offsetbox.py build/lib.linux-x86_64-3.2/matplotlib/_cm.py build/lib.linux-x86_64-3.2/matplotlib/patheffects.py build/lib.linux-x86_64-3.2/matplotlib/path.py build/lib.linux-x86_64-3.2/matplotlib/mpl.py build/lib.linux-x86_64-3.2/matplotlib/texmanager.py build/lib.linux-x86_64-3.2/matplotlib/scale.py build/lib.linux-x86_64-3.2/matplotlib/spines.py build/lib.linux-x86_64-3.2/matplotlib/_pylab_helpers.py build/lib.linux-x86_64-3.2/matplotlib/mlab.py build/lib.linux-x86_64-3.2/matplotlib/fontconfig_pattern.py build/lib.linux-x86_64-3.2/matplotlib/patches.py build/lib.linux-x86_64-3.2/matplotlib/bezier.py build/lib.linux-x86_64-3.2/matplotlib/image.py build/lib.linux-x86_64-3.2/matplotlib/stackplot.py build/lib.linux-x86_64-3.2/matplotlib/__init__.py build/lib.linux-x86_64-3.2/matplotlib/rcsetup.py build/lib.linux-x86_64-3.2/matplotlib/sankey.py build/lib.linux-x86_64-3.2/matplotlib/transforms.py build/lib.linux-x86_64-3.2/matplotlib/streamplot.py build/lib.linux-x86_64-3.2/matplotlib/ticker.py build/lib.linux-x86_64-3.2/matplotlib/axis.py build/lib.linux-x86_64-3.2/matplotlib/pyplot.py build/lib.linux-x86_64-3.2/matplotlib/text.py build/lib.linux-x86_64-3.2/matplotlib/cm.py build/lib.linux-x86_64-3.2/matplotlib/colors.py build/lib.linux-x86_64-3.2/matplotlib/table.py build/lib.linux-x86_64-3.2/matplotlib/collections.py build/lib.linux-x86_64-3.2/matplotlib/dviread.py build/lib.linux-x86_64-3.2/matplotlib/units.py build/lib.linux-x86_64-3.2/matplotlib/blocking_input.py build/lib.linux-x86_64-3.2/matplotlib/_mathtext_data.py build/lib.linux-x86_64-3.2/matplotlib/quiver.py build/lib.linux-x86_64-3.2/matplotlib/textpath.py build/lib.linux-x86_64-3.2/matplotlib/cbook.py build/lib.linux-x86_64-3.2/matplotlib/pylab.py build/lib.linux-x86_64-3.2/matplotlib/tight_bbox.py build/lib.linux-x86_64-3.2/matplotlib/type1font.py build/lib.linux-x86_64-3.2/matplotlib/axes.py build/lib.linux-x86_64-3.2/matplotlib/mathtext.py build/lib.linux-x86_64-3.2/matplotlib/backend_bases.py build/lib.linux-x86_64-3.2/matplotlib/artist.py build/lib.linux-x86_64-3.2/matplotlib/hatch.py build/lib.linux-x86_64-3.2/matplotlib/widgets.py build/lib.linux-x86_64-3.2/matplotlib/container.py build/lib.linux-x86_64-3.2/matplotlib/docstring.py build/lib.linux-x86_64-3.2/matplotlib/font_manager.py build/lib.linux-x86_64-3.2/matplotlib/animation.py build/lib.linux-x86_64-3.2/matplotlib/legend_handler.py build/lib.linux-x86_64-3.2/matplotlib/lines.py build/lib.linux-x86_64-3.2/matplotlib/figure.py build/lib.linux-x86_64-3.2/matplotlib/afm.py build/lib.linux-x86_64-3.2/matplotlib/finance.py build/lib.linux-x86_64-3.2/matplotlib/tight_layout.py build/lib.linux-x86_64-3.2/matplotlib/gridspec.py build/lib.linux-x86_64-3.2/matplotlib/dates.py build/lib.linux-x86_64-3.2/matplotlib/contour.py build/lib.linux-x86_64-3.2/matplotlib/markers.py build/lib.linux-x86_64-3.2/matplotlib/legend.py build/lib.linux-x86_64-3.2/matplotlib/colorbar.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_wxagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtk3cairo.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_pgf.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_cairo.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_cocoaagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/qt4_compat.py build/lib.linux-x86_64-3.2/matplotlib/backends/__init__.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtk3agg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gdk.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_ps.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_pdf.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_qt4agg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_mixed.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_template.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtk.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_qt4.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_webagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/tkagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtkcairo.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_svg.py build/lib.linux-x86_64-3.2/matplotlib/backends/windowing.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_tkagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_wx.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_agg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtkagg.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_macosx.py build/lib.linux-x86_64-3.2/matplotlib/backends/backend_gtk3.py build/lib.linux-x86_64-3.2/matplotlib/backends/qt4_editor/formlayout.py build/lib.linux-x86_64-3.2/matplotlib/backends/qt4_editor/__init__.py build/lib.linux-x86_64-3.2/matplotlib/backends/qt4_editor/figureoptions.py build/lib.linux-x86_64-3.2/matplotlib/compat/__init__.py build/lib.linux-x86_64-3.2/matplotlib/compat/subprocess.py build/lib.linux-x86_64-3.2/matplotlib/projections/__init__.py build/lib.linux-x86_64-3.2/matplotlib/projections/polar.py build/lib.linux-x86_64-3.2/matplotlib/projections/geo.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/plot_directive.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/__init__.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/ipython_directive.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/ipython_console_highlighting.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/mathmpl.py build/lib.linux-x86_64-3.2/matplotlib/sphinxext/only_directives.py build/lib.linux-x86_64-3.2/matplotlib/testing/__init__.py build/lib.linux-x86_64-3.2/matplotlib/testing/compare.py build/lib.linux-x86_64-3.2/matplotlib/testing/noseclasses.py build/lib.linux-x86_64-3.2/matplotlib/testing/image_util.py build/lib.linux-x86_64-3.2/matplotlib/testing/decorators.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/__init__.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/UnitDblConverter.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/EpochConverter.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/UnitDbl.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/Duration.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/StrConverter.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/UnitDblFormatter.py build/lib.linux-x86_64-3.2/matplotlib/testing/jpl_units/Epoch.py build/lib.linux-x86_64-3.2/matplotlib/tri/tritools.py build/lib.linux-x86_64-3.2/matplotlib/tri/triplot.py build/lib.linux-x86_64-3.2/matplotlib/tri/triangulation.py build/lib.linux-x86_64-3.2/matplotlib/tri/__init__.py build/lib.linux-x86_64-3.2/matplotlib/tri/trifinder.py build/lib.linux-x86_64-3.2/matplotlib/tri/trirefine.py build/lib.linux-x86_64-3.2/matplotlib/tri/triinterpolate.py build/lib.linux-x86_64-3.2/matplotlib/tri/tricontour.py build/lib.linux-x86_64-3.2/matplotlib/tri/tripcolor.py build/lib.linux-x86_64-3.2/matplotlib/delaunay/__init__.py build/lib.linux-x86_64-3.2/matplotlib/delaunay/triangulate.py build/lib.linux-x86_64-3.2/matplotlib/delaunay/testfuncs.py build/lib.linux-x86_64-3.2/matplotlib/delaunay/interpolate.py build/lib.linux-x86_64-3.2/mpl_toolkits/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/gtktools.py build/lib.linux-x86_64-3.2/mpl_toolkits/exceltools.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/axes3d.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/proj3d.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/art3d.py build/lib.linux-x86_64-3.2/mpl_toolkits/mplot3d/axis3d.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axes_divider.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/floating_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/grid_finder.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/angle_helper.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axes_grid.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/grid_helper_curvelinear.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/clip_path.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axislines.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/parasite_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axisline_style.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axes_size.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/inset_locator.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axes_rgb.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/anchored_artists.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/axis_artist.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid/colorbar.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/axes_divider.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/axes_grid.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/parasite_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/mpl_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/axes_size.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/inset_locator.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/axes_rgb.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/anchored_artists.py build/lib.linux-x86_64-3.2/mpl_toolkits/axes_grid1/colorbar.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/floating_axes.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/__init__.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/grid_finder.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/angle_helper.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/grid_helper_curvelinear.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/clip_path.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/axislines.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/axisline_style.py build/lib.linux-x86_64-3.2/mpl_toolkits/axisartist/axis_artist.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_basic.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_contour.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_image.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_mlab.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_dates.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_legend.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_cbook.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_axes.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_dviread.py build/lib.linux-x86_64-3.2/matplotlib/tests/__init__.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_triangulation.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_path.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_patches.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_text.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_coding_standards.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_spines.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_table.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_backend_pdf.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_delaunay.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_ticker.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_artist.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_colorbar.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_png.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_simplification.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_transforms.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_pickle.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_figure.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_bbox_tight.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_animation.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_collections.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_streamplot.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_backend_qt4.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_compare_images.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_backend_svg.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_backend_pgf.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_patheffects.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_sankey.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_scale.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_mathtext.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_lines.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_tightlayout.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_ttconv.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_colors.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_subplots.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_rcparams.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_arrow_patches.py build/lib.linux-x86_64-3.2/matplotlib/tests/test_agg.py
    Skipping implicit fixer: buffer
    Skipping implicit fixer: idioms
    Skipping implicit fixer: set_literal
    Skipping implicit fixer: ws_comma
    building 'matplotlib.ft2font' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ft2font_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/freetype2 -I/usr/include/python3.2mu -c src/ft2font.cpp -o build/temp.linux-x86_64-3.2/src/ft2font.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from src/ft2font.cpp:7:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ft2font_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/freetype2 -I/usr/include/python3.2mu -c src/mplutils.cpp -o build/temp.linux-x86_64-3.2/src/mplutils.o
    In file included from /usr/include/python3.2mu/Python.h:8:0,
                     from src/mplutils.h:18,
                     from src/mplutils.cpp:6:
    /usr/include/python3.2mu/pyconfig.h:1182:0: warning: "_POSIX_C_SOURCE" redefined [enabled by default]
    /usr/include/features.h:164:0: note: this is the location of the previous definition
    /usr/include/python3.2mu/pyconfig.h:1204:0: warning: "_XOPEN_SOURCE" redefined [enabled by default]
    /usr/include/features.h:166:0: note: this is the location of the previous definition
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ft2font_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/freetype2 -I/usr/include/python3.2mu -c CXX/cxx_extensions.cxx -o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ft2font_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/freetype2 -I/usr/include/python3.2mu -c CXX/IndirectPythonInterface.cxx -o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ft2font_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/freetype2 -I/usr/include/python3.2mu -c CXX/cxxsupport.cxx -o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ft2font_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/freetype2 -I/usr/include/python3.2mu -c CXX/cxxextensions.c -o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o
    g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/src/ft2font.o build/temp.linux-x86_64-3.2/src/mplutils.o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o -L/usr/local/lib -lfreetype -lstdc++ -lm -o build/lib.linux-x86_64-3.2/matplotlib/ft2font.cpython-32mu.so
    building 'matplotlib._png' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__png_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/libpng12 -I/usr/include/python3.2mu -c src/_png.cpp -o build/temp.linux-x86_64-3.2/src/_png.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from src/_png.cpp:28:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    In file included from src/file_compat.h:4:0,
                     from src/_png.cpp:31:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘FILE* npy_PyFile_Dup2(PyObject*, char*, off_t*)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:156:48: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:156:48: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:172:49: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:172:49: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:200:47: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:200:47: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘int npy_PyFile_DupClose2(PyObject*, FILE*, off_t)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:251:77: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:251:77: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘int npy_PyFile_DupClose(PyObject*, FILE*)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:303:79: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:303:79: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘PyObject* npy_PyFile_OpenFile(PyObject*, const char*)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:332:60: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘int npy_PyFile_CloseFile(PyObject*)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:340:50: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    src/_png.cpp: In member function ‘PyObject* _png_module::_read_png(const Py::Object&, bool, int)’:
    src/_png.cpp:329:43: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__png_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/libpng12 -I/usr/include/python3.2mu -c src/mplutils.cpp -o build/temp.linux-x86_64-3.2/src/mplutils.o
    In file included from /usr/include/python3.2mu/Python.h:8:0,
                     from src/mplutils.h:18,
                     from src/mplutils.cpp:6:
    /usr/include/python3.2mu/pyconfig.h:1182:0: warning: "_POSIX_C_SOURCE" redefined [enabled by default]
    /usr/include/features.h:164:0: note: this is the location of the previous definition
    /usr/include/python3.2mu/pyconfig.h:1204:0: warning: "_XOPEN_SOURCE" redefined [enabled by default]
    /usr/include/features.h:166:0: note: this is the location of the previous definition
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__png_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/libpng12 -I/usr/include/python3.2mu -c CXX/cxx_extensions.cxx -o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__png_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/libpng12 -I/usr/include/python3.2mu -c CXX/IndirectPythonInterface.cxx -o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__png_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/libpng12 -I/usr/include/python3.2mu -c CXX/cxxsupport.cxx -o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__png_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/libpng12 -I/usr/include/python3.2mu -c CXX/cxxextensions.c -o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o
    g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/src/_png.o build/temp.linux-x86_64-3.2/src/mplutils.o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o -L/usr/local/lib -lpng12 -lstdc++ -lm -o build/lib.linux-x86_64-3.2/matplotlib/_png.cpython-32mu.so
    building 'matplotlib._image' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c src/_image.cpp -o build/temp.linux-x86_64-3.2/src/_image.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from src/_image.cpp:12:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c src/mplutils.cpp -o build/temp.linux-x86_64-3.2/src/mplutils.o
    In file included from /usr/include/python3.2mu/Python.h:8:0,
                     from src/mplutils.h:18,
                     from src/mplutils.cpp:6:
    /usr/include/python3.2mu/pyconfig.h:1182:0: warning: "_POSIX_C_SOURCE" redefined [enabled by default]
    /usr/include/features.h:164:0: note: this is the location of the previous definition
    /usr/include/python3.2mu/pyconfig.h:1204:0: warning: "_XOPEN_SOURCE" redefined [enabled by default]
    /usr/include/features.h:166:0: note: this is the location of the previous definition
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_bezier_arc.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_bezier_arc.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_curves.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_curves.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_image_filters.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_image_filters.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_trans_affine.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_trans_affine.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_vcgen_contour.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_contour.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_vcgen_dash.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_dash.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_vcgen_stroke.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_stroke.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_vpgen_segmentator.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vpgen_segmentator.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c CXX/cxx_extensions.cxx -o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c CXX/IndirectPythonInterface.cxx -o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c CXX/cxxsupport.cxx -o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__image_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c CXX/cxxextensions.c -o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o
    g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/src/_image.o build/temp.linux-x86_64-3.2/src/mplutils.o build/temp.linux-x86_64-3.2/agg24/src/agg_bezier_arc.o build/temp.linux-x86_64-3.2/agg24/src/agg_curves.o build/temp.linux-x86_64-3.2/agg24/src/agg_image_filters.o build/temp.linux-x86_64-3.2/agg24/src/agg_trans_affine.o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_contour.o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_dash.o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_stroke.o build/temp.linux-x86_64-3.2/agg24/src/agg_vpgen_segmentator.o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o -L/usr/local/lib -lstdc++ -lm -o build/lib.linux-x86_64-3.2/matplotlib/_image.cpython-32mu.so
    building 'matplotlib.ttconv' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ttconv_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c src/_ttconv.cpp -o build/temp.linux-x86_64-3.2/src/_ttconv.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ttconv_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c ttconv/pprdrv_tt.cpp -o build/temp.linux-x86_64-3.2/ttconv/pprdrv_tt.o
    In file included from /usr/include/python3.2mu/Python.h:8:0,
                     from ttconv/pprdrv_tt.cpp:34:
    /usr/include/python3.2mu/pyconfig.h:1182:0: warning: "_POSIX_C_SOURCE" redefined [enabled by default]
    /usr/include/features.h:164:0: note: this is the location of the previous definition
    /usr/include/python3.2mu/pyconfig.h:1204:0: warning: "_XOPEN_SOURCE" redefined [enabled by default]
    /usr/include/features.h:166:0: note: this is the location of the previous definition
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ttconv_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c ttconv/pprdrv_tt2.cpp -o build/temp.linux-x86_64-3.2/ttconv/pprdrv_tt2.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ttconv_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c ttconv/ttutil.cpp -o build/temp.linux-x86_64-3.2/ttconv/ttutil.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ttconv_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c CXX/cxx_extensions.cxx -o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ttconv_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c CXX/IndirectPythonInterface.cxx -o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ttconv_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c CXX/cxxsupport.cxx -o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_ttconv_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c CXX/cxxextensions.c -o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o
    g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/src/_ttconv.o build/temp.linux-x86_64-3.2/ttconv/pprdrv_tt.o build/temp.linux-x86_64-3.2/ttconv/pprdrv_tt2.o build/temp.linux-x86_64-3.2/ttconv/ttutil.o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o -L/usr/local/lib -lstdc++ -lm -o build/lib.linux-x86_64-3.2/matplotlib/ttconv.cpython-32mu.so
    building 'matplotlib._path' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c src/_path.cpp -o build/temp.linux-x86_64-3.2/src/_path.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from src/agg_py_path_iterator.h:7,
                     from src/_path.cpp:3:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c src/path_cleanup.cpp -o build/temp.linux-x86_64-3.2/src/path_cleanup.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from src/path_cleanup.cpp:5:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c src/agg_py_transforms.cpp -o build/temp.linux-x86_64-3.2/src/agg_py_transforms.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from src/agg_py_transforms.cpp:6:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_bezier_arc.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_bezier_arc.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_curves.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_curves.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_image_filters.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_image_filters.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_trans_affine.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_trans_affine.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_vcgen_contour.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_contour.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_vcgen_dash.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_dash.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_vcgen_stroke.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_stroke.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c agg24/src/agg_vpgen_segmentator.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vpgen_segmentator.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c CXX/cxx_extensions.cxx -o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c CXX/IndirectPythonInterface.cxx -o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c CXX/cxxsupport.cxx -o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__path_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/python3.2mu -c CXX/cxxextensions.c -o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o
    g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/src/_path.o build/temp.linux-x86_64-3.2/src/path_cleanup.o build/temp.linux-x86_64-3.2/src/agg_py_transforms.o build/temp.linux-x86_64-3.2/agg24/src/agg_bezier_arc.o build/temp.linux-x86_64-3.2/agg24/src/agg_curves.o build/temp.linux-x86_64-3.2/agg24/src/agg_image_filters.o build/temp.linux-x86_64-3.2/agg24/src/agg_trans_affine.o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_contour.o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_dash.o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_stroke.o build/temp.linux-x86_64-3.2/agg24/src/agg_vpgen_segmentator.o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o -L/usr/local/lib -lstdc++ -lm -o build/lib.linux-x86_64-3.2/matplotlib/_path.cpython-32mu.so
    building 'matplotlib._cntr' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__cntr_ARRAY_API -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c src/cntr.c -o build/temp.linux-x86_64-3.2/src/cntr.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from src/cntr.c:23:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/src/cntr.o -L/usr/local/lib -o build/lib.linux-x86_64-3.2/matplotlib/_cntr.cpython-32mu.so
    building 'matplotlib._delaunay' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__delaunay_ARRAY_API -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c lib/matplotlib/delaunay/_delaunay.cpp -o build/temp.linux-x86_64-3.2/lib/matplotlib/delaunay/_delaunay.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from lib/matplotlib/delaunay/VoronoiDiagramGenerator.h:34,
                     from lib/matplotlib/delaunay/_delaunay.cpp:6:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__delaunay_ARRAY_API -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c lib/matplotlib/delaunay/VoronoiDiagramGenerator.cpp -o build/temp.linux-x86_64-3.2/lib/matplotlib/delaunay/VoronoiDiagramGenerator.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from lib/matplotlib/delaunay/VoronoiDiagramGenerator.cpp:38:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    lib/matplotlib/delaunay/VoronoiDiagramGenerator.cpp: In member function ‘bool VoronoiDiagramGenerator::voronoi(int)’:
    lib/matplotlib/delaunay/VoronoiDiagramGenerator.cpp:946:9: warning: ‘newintstar.Point::y’ may be used uninitialized in this function [-Wuninitialized]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__delaunay_ARRAY_API -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c lib/matplotlib/delaunay/delaunay_utils.cpp -o build/temp.linux-x86_64-3.2/lib/matplotlib/delaunay/delaunay_utils.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__delaunay_ARRAY_API -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c lib/matplotlib/delaunay/natneighbors.cpp -o build/temp.linux-x86_64-3.2/lib/matplotlib/delaunay/natneighbors.o
    g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/lib/matplotlib/delaunay/_delaunay.o build/temp.linux-x86_64-3.2/lib/matplotlib/delaunay/VoronoiDiagramGenerator.o build/temp.linux-x86_64-3.2/lib/matplotlib/delaunay/delaunay_utils.o build/temp.linux-x86_64-3.2/lib/matplotlib/delaunay/natneighbors.o -L/usr/local/lib -o build/lib.linux-x86_64-3.2/matplotlib/_delaunay.cpython-32mu.so
    building 'matplotlib._tri' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__tri_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c lib/matplotlib/tri/_tri.cpp -o build/temp.linux-x86_64-3.2/lib/matplotlib/tri/_tri.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from lib/matplotlib/tri/_tri.h:68,
                     from lib/matplotlib/tri/_tri.cpp:8:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__tri_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c src/mplutils.cpp -o build/temp.linux-x86_64-3.2/src/mplutils.o
    In file included from /usr/include/python3.2mu/Python.h:8:0,
                     from src/mplutils.h:18,
                     from src/mplutils.cpp:6:
    /usr/include/python3.2mu/pyconfig.h:1182:0: warning: "_POSIX_C_SOURCE" redefined [enabled by default]
    /usr/include/features.h:164:0: note: this is the location of the previous definition
    /usr/include/python3.2mu/pyconfig.h:1204:0: warning: "_XOPEN_SOURCE" redefined [enabled by default]
    /usr/include/features.h:166:0: note: this is the location of the previous definition
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__tri_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c CXX/cxx_extensions.cxx -o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__tri_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c CXX/IndirectPythonInterface.cxx -o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__tri_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c CXX/cxxsupport.cxx -o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib__tri_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -I/usr/include/python3.2mu -c CXX/cxxextensions.c -o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o
    g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/lib/matplotlib/tri/_tri.o build/temp.linux-x86_64-3.2/src/mplutils.o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o -L/usr/local/lib -lstdc++ -lm -o build/lib.linux-x86_64-3.2/matplotlib/_tri.cpython-32mu.so
    building 'matplotlib.backends._backend_agg' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c src/mplutils.cpp -o build/temp.linux-x86_64-3.2/src/mplutils.o
    In file included from /usr/include/python3.2mu/Python.h:8:0,
                     from src/mplutils.h:18,
                     from src/mplutils.cpp:6:
    /usr/include/python3.2mu/pyconfig.h:1182:0: warning: "_POSIX_C_SOURCE" redefined [enabled by default]
    /usr/include/features.h:164:0: note: this is the location of the previous definition
    /usr/include/python3.2mu/pyconfig.h:1204:0: warning: "_XOPEN_SOURCE" redefined [enabled by default]
    /usr/include/features.h:166:0: note: this is the location of the previous definition
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c src/agg_py_transforms.cpp -o build/temp.linux-x86_64-3.2/src/agg_py_transforms.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from src/agg_py_transforms.cpp:6:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c src/_backend_agg.cpp -o build/temp.linux-x86_64-3.2/src/_backend_agg.o
    In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                     from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                     from src/agg_py_path_iterator.h:7,
                     from src/_backend_agg.h:43,
                     from src/_backend_agg.cpp:12:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    In file included from src/file_compat.h:4:0,
                     from src/_backend_agg.cpp:44:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘FILE* npy_PyFile_Dup2(PyObject*, char*, off_t*)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:156:48: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:156:48: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:172:49: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:172:49: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:200:47: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:200:47: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘int npy_PyFile_DupClose2(PyObject*, FILE*, off_t)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:251:77: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:251:77: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘int npy_PyFile_DupClose(PyObject*, FILE*)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:303:79: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:303:79: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘PyObject* npy_PyFile_OpenFile(PyObject*, const char*)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:332:60: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h: In function ‘int npy_PyFile_CloseFile(PyObject*)’:
    /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_3kcompat.h:340:50: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
    src/_backend_agg.cpp: In member function ‘Py::Object RendererAgg::draw_markers(const Py::Tuple&)’:
    src/_backend_agg.cpp:782:21: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    src/_backend_agg.cpp:782:45: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    src/_backend_agg.cpp:820:21: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    src/_backend_agg.cpp:820:45: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c agg24/src/agg_bezier_arc.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_bezier_arc.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c agg24/src/agg_curves.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_curves.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c agg24/src/agg_image_filters.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_image_filters.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c agg24/src/agg_trans_affine.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_trans_affine.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c agg24/src/agg_vcgen_contour.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_contour.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c agg24/src/agg_vcgen_dash.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_dash.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c agg24/src/agg_vcgen_stroke.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_stroke.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c agg24/src/agg_vpgen_segmentator.cpp -o build/temp.linux-x86_64-3.2/agg24/src/agg_vpgen_segmentator.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c CXX/cxx_extensions.cxx -o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c CXX/IndirectPythonInterface.cxx -o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c CXX/cxxsupport.cxx -o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -DPY_ARRAY_UNIQUE_SYMBOL=MPL_matplotlib_backends__backend_agg_ARRAY_API -DPYCXX_ISO_CPP_LIB=1 -DPYCXX_PYTHON_2TO3=1 -I/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I. -Iagg24/include -I/usr/include/freetype2 -I/usr/include/python3.2mu -c CXX/cxxextensions.c -o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o
    g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/src/mplutils.o build/temp.linux-x86_64-3.2/src/agg_py_transforms.o build/temp.linux-x86_64-3.2/src/_backend_agg.o build/temp.linux-x86_64-3.2/agg24/src/agg_bezier_arc.o build/temp.linux-x86_64-3.2/agg24/src/agg_curves.o build/temp.linux-x86_64-3.2/agg24/src/agg_image_filters.o build/temp.linux-x86_64-3.2/agg24/src/agg_trans_affine.o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_contour.o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_dash.o build/temp.linux-x86_64-3.2/agg24/src/agg_vcgen_stroke.o build/temp.linux-x86_64-3.2/agg24/src/agg_vpgen_segmentator.o build/temp.linux-x86_64-3.2/CXX/cxx_extensions.o build/temp.linux-x86_64-3.2/CXX/IndirectPythonInterface.o build/temp.linux-x86_64-3.2/CXX/cxxsupport.o build/temp.linux-x86_64-3.2/CXX/cxxextensions.o -L/usr/local/lib -lfreetype -lstdc++ -lm -o build/lib.linux-x86_64-3.2/matplotlib/backends/_backend_agg.cpython-32mu.so
    Skipping installation of /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/mpl_toolkits/__init__.py (namespace package)

    Installing /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/matplotlib-1.3.1-py3.2-nspkg.pth
  Running setup.py install for networkx

    warning: no files found matching 'scripts/*'
    warning: no files found matching 'networkx/tests/*.txt'
    warning: no files found matching 'networkx/*/*/tests/*.txt'
    warning: no previously-included files matching '*~' found anywhere in distribution
    warning: no previously-included files matching '*.pyc' found anywhere in distribution
    warning: no previously-included files matching '.svn' found anywhere in distribution
    no previously-included directories found matching 'doc/build'
    no previously-included directories found matching 'doc/source/reference/generated'
    no previously-included directories found matching 'doc/source/examples'
    no previously-included directories found matching 'doc/source/static/examples'
    no previously-included directories found matching 'doc/source/templates/gallery.html'
  Found existing installation: nose 1.3.4
    Uninstalling nose:
      Successfully uninstalled nose
  Running setup.py install for nose
    Fixing build/lib/nose/core.py build/lib/nose/__init__.py build/lib/nose/exc.py build/lib/nose/loader.py build/lib/nose/inspector.py build/lib/nose/pyversion.py build/lib/nose/selector.py build/lib/nose/proxy.py build/lib/nose/__main__.py build/lib/nose/suite.py build/lib/nose/config.py build/lib/nose/importer.py build/lib/nose/failure.py build/lib/nose/result.py build/lib/nose/util.py build/lib/nose/commands.py build/lib/nose/case.py build/lib/nose/twistedtools.py build/lib/nose/plugins/isolate.py build/lib/nose/plugins/capture.py build/lib/nose/plugins/__init__.py build/lib/nose/plugins/skip.py build/lib/nose/plugins/collect.py build/lib/nose/plugins/manager.py build/lib/nose/plugins/doctests.py build/lib/nose/plugins/deprecated.py build/lib/nose/plugins/errorclass.py build/lib/nose/plugins/attrib.py build/lib/nose/plugins/builtin.py build/lib/nose/plugins/allmodules.py build/lib/nose/plugins/base.py build/lib/nose/plugins/testid.py build/lib/nose/plugins/failuredetail.py build/lib/nose/plugins/logcapture.py build/lib/nose/plugins/plugintest.py build/lib/nose/plugins/xunit.py build/lib/nose/plugins/prof.py build/lib/nose/plugins/multiprocess.py build/lib/nose/plugins/cover.py build/lib/nose/plugins/debug.py build/lib/nose/tools/__init__.py build/lib/nose/tools/nontrivial.py build/lib/nose/tools/trivial.py build/lib/nose/ext/__init__.py build/lib/nose/ext/dtcompat.py build/lib/nose/sphinx/__init__.py build/lib/nose/sphinx/pluginopts.py
    Skipping implicit fixer: buffer
    Skipping implicit fixer: idioms
    Skipping implicit fixer: set_literal
    Skipping implicit fixer: ws_comma
    Fixing build/lib/nose/core.py build/lib/nose/__init__.py build/lib/nose/exc.py build/lib/nose/loader.py build/lib/nose/inspector.py build/lib/nose/pyversion.py build/lib/nose/selector.py build/lib/nose/proxy.py build/lib/nose/__main__.py build/lib/nose/suite.py build/lib/nose/config.py build/lib/nose/importer.py build/lib/nose/failure.py build/lib/nose/result.py build/lib/nose/util.py build/lib/nose/commands.py build/lib/nose/case.py build/lib/nose/twistedtools.py build/lib/nose/plugins/isolate.py build/lib/nose/plugins/capture.py build/lib/nose/plugins/__init__.py build/lib/nose/plugins/skip.py build/lib/nose/plugins/collect.py build/lib/nose/plugins/manager.py build/lib/nose/plugins/doctests.py build/lib/nose/plugins/deprecated.py build/lib/nose/plugins/errorclass.py build/lib/nose/plugins/attrib.py build/lib/nose/plugins/builtin.py build/lib/nose/plugins/allmodules.py build/lib/nose/plugins/base.py build/lib/nose/plugins/testid.py build/lib/nose/plugins/failuredetail.py build/lib/nose/plugins/logcapture.py build/lib/nose/plugins/plugintest.py build/lib/nose/plugins/xunit.py build/lib/nose/plugins/prof.py build/lib/nose/plugins/multiprocess.py build/lib/nose/plugins/cover.py build/lib/nose/plugins/debug.py build/lib/nose/tools/__init__.py build/lib/nose/tools/nontrivial.py build/lib/nose/tools/trivial.py build/lib/nose/ext/__init__.py build/lib/nose/ext/dtcompat.py build/lib/nose/sphinx/__init__.py build/lib/nose/sphinx/pluginopts.py
    Skipping implicit fixer: buffer
    Skipping implicit fixer: idioms
    Skipping implicit fixer: set_literal
    Skipping implicit fixer: ws_comma

    no previously-included directories found matching 'doc/.build'
    Installing nosetests script to /home/travis/virtualenv/python3.2_with_system_site_packages/bin
    Installing nosetests-3.2 script to /home/travis/virtualenv/python3.2_with_system_site_packages/bin
  Running setup.py install for python-dateutil

  Running setup.py install for tornado
    building 'tornado.speedups' extension
    gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC -I/usr/include/python3.2mu -c tornado/speedups.c -o build/temp.linux-x86_64-3.2/tornado/speedups.o
    tornado/speedups.c:44:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
    gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro build/temp.linux-x86_64-3.2/tornado/speedups.o -o build/lib.linux-x86_64-3.2/tornado/speedups.cpython-32mu.so

  Running setup.py install for pyparsing

  Running setup.py install for certifi

Successfully installed Cython matplotlib networkx nose python-dateutil tornado pyparsing six certifi
Cleaning up...
56.34s$ nosetests -s -w tests/
warning: /home/travis/build/jmschrei/yahmm/yahmm/yahmm.pyx:1899:41: Index should be typed for more efficient access
In file included from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarraytypes.h:1761:0,
                 from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/ndarrayobject.h:17,
                 from /home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                 from /home/travis/.pyxbld/temp.linux-x86_64-3.2/pyrex/yahmm/yahmm.c:347:
/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/__multiarray_api.h:1629:1: warning: ‘_import_array’ defined but not used [-Wunused-function]
/home/travis/virtualenv/python3.2_with_system_site_packages/lib/python3.2/site-packages/numpy/core/include/numpy/__ufunc_api.h:241:1: warning: ‘_import_umath’ defined but not used [-Wunused-function]
/home/travis/.pyxbld/temp.linux-x86_64-3.2/pyrex/yahmm/yahmm.c: In function ‘__pyx_f_5yahmm_5yahmm_5Model__sample’:
/home/travis/.pyxbld/temp.linux-x86_64-3.2/pyrex/yahmm/yahmm.c:33242:18: warning: ‘__pyx_v_k’ may be used uninitialized in this function [-Wuninitialized]
/home/travis/build.sh: line 41:  2801 Segmentation fault      nosetests -s -w tests/
The command "nosetests -s -w tests/" exited with 139.
Done. Your build exited with 1.
```

This is the log. 
