### PR TITLE
Fix issue #41: yahmm not importing correctly on python 3.4 

### DIFF
--- a/yahmm/__init__.py
+++ b/yahmm/__init__.py
@@ -43,6 +43,6 @@ elif os.name == 'posix':
     pyximport.install()
 
 
-from yahmm import *
+from .yahmm import *
 
 __version__ = '1.1.2'


### PR DESCRIPTION
It is not clear whether 'from yahmm import *' refers to top-level module or the module inside the package. So the order of the search path can cause the problem in #41.